### PR TITLE
Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: go
+
+go:
+- 1.13.x
+
+jobs:
+  include:
+    - stage: build
+      script:
+        - go get ./...
+        - go test ./...
+      deploy:
+        provider: releases
+        api_key: $GH_TOKEN
+        skip_cleanup: true
+        on:
+          # Creates a new deployment when a tag is pushed to master
+          branch: master
+          tags: true
+


### PR DESCRIPTION
Requires that the Travis CI service has the correct permissions to the
repository, and that an environment variable called GH_TOKEN is present.