### PR TITLE
Event stream func

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,41 +207,36 @@ err := j.Register(&Person{}, &Born{}, &AgedOneYear{})
 
 The unsafe serializer stores the underlying memory representation of a struct directly. This makes it as its name implies, unsafe to use if you are unsure what you are doing. [Here](https://youtu.be/4xB46Xl9O9Q?t=610) is the video that explains the reason for this serializer.
 
-### Event Stream
+### Event Subscription
 
-The repository expose the `EventStream(events ...interface{}) observer.Stream` function that makes it possible to subscribe on saved events.
-The returned stream will collect all events that has occurred after the call to the function and its possible to iterate over them via the functions from the [go-observer](https://github.com/imkira/go-observer) pkg (that is the pkg we use to accomplish this).  
+The repository expose the `Subscribe(func(e eventsourcing.Event), events ...interface{})` function that makes it possible to subscribe on saved events in realtime.
+The function `func(e eventcourcing.Event)` will be called when and subscribed to event is saved in the repository. 
 
-If no events are included in the input `repo.EventStream()` all saved events will be present in the stream.
-When events `repo.EventStream(&FrequentFlierAccountCreated{}, &StatusMatched{})` only those events with that type will be present in the stream.
+If no events are included in the input `repo.Subscribe(func(e eventsourcing.Event))` all saved events will be exposed via the `func(e eventsourcing.Event)` function.
+When events `repo.Subscribe(func(e eventsourcing.Event),&FrequentFlierAccountCreated{}, &StatusMatched{})` only those events with that type will be exposed via the function.
 There is no restrictions that the events need to come from the same aggregate type, you can mix and match as you please.
 
-The stream is realtime and events that are saved before the call to the EventStream function will not be present on the stream. If the application 
-depends on this functionality make sure to call the function before any events are saved. 
+The subscription is realtime and events that are saved before the call to the Subscribe function will not be exposed via the `func(e eventsourcing.Event)` function. If the application 
+depends on this functionality make sure to call the `repo.Subscribe` function before any events are saved. 
 
-The event stream enables the application to make use of the reactive patterns and to make it more decoupled. Check out the [Reactive Manifesto](https://www.reactivemanifesto.org/) 
+The event subscription enables the application to make use of the reactive patterns and to make it more decoupled. Check out the [Reactive Manifesto](https://www.reactivemanifesto.org/) 
 for more detailed information. 
 
-Example on how to setup the event stream and consume the event `FrequentFlierAccountCreated`
+Example on how to setup the event subscription and consume the event `FrequentFlierAccountCreated`
 
 ```go
 // Setup a memory based repository
 repo := eventsourcing.NewRepository(memory.Create(unsafe.New()), nil)
-stream := repo.EventStream()
-	
-// Read the event stream async 
-go func() { 
-    for {
-        // wait for an event to be accessible on the stream
-        event := stream.WaitNext().(eventsourcing.Event)
-        // use similar switch as in the Transition function from the aggregate
-        switch e := event.Data.(type) {
-        case *FrequentFlierAccountCreated:
-            // e now have type info
-            fmt.Println(e)
-        }
-    }
-}()
+f := func(e eventsourcing.Event) {
+	switch e := event.Data.(type) {
+       	case *FrequentFlierAccountCreated:
+        	// e now have type info
+            	fmt.Println(e)
+       }
+}
+
+// subscribe to all events
+repo.Subscribe(f)
 ```
 
 ## Custom made components

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -15,56 +15,66 @@ var event = eventsourcing.Event{Version: 123, Data: &AnEvent{Name: "123"}}
 var otherEvent = eventsourcing.Event{Version: 123, Data: &AnotherEvent{}}
 
 func TestGlobal(t *testing.T) {
+	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
-	stream := e.Subscribe()
+	f := func(e eventsourcing.Event) {
+		streamEvent = &e
+	}
+	e.Subscribe(f)
 	e.Update(event)
 
-	if !stream.HasNext() {
+	//time.Sleep(1 * time.Second)
+	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
-
-	streamEvent := stream.WaitNext().(eventsourcing.Event)
 	if streamEvent.Version != event.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, event.Version)
 	}
 }
 
+
 func TestSpecific(t *testing.T) {
+	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
-	stream := e.Subscribe(&AnEvent{})
+	f := func(e eventsourcing.Event) {
+		streamEvent = &e
+	}
+	e.Subscribe(f,&AnEvent{})
 	e.Update(event)
 
-	if !stream.HasNext() {
+	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
 
-	streamEvent := stream.WaitNext().(eventsourcing.Event)
 	if streamEvent.Version != event.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, event.Version)
 	}
 }
 
 func TestManySpecific(t *testing.T) {
+	var streamEvents []*eventsourcing.Event
 	e := eventsourcing.NewEventStream()
-	stream := e.Subscribe(&AnEvent{}, &AnotherEvent{})
+	f := func(e eventsourcing.Event) {
+		streamEvents = append(streamEvents, &e)
+	}
+	e.Subscribe(f, &AnEvent{}, &AnotherEvent{})
 	e.Update(event)
 	e.Update(otherEvent)
 
-	if !stream.HasNext() {
+	if streamEvents == nil {
 		t.Fatalf("should have received event")
 	}
 
-	streamEvent := stream.WaitNext().(eventsourcing.Event)
-	switch ev := streamEvent.Data.(type) {
+	if len(streamEvents) != 2 {
+		t.Fatalf("should have received 2 events")
+	}
+
+	switch ev := streamEvents[0].Data.(type) {
 	case *AnotherEvent:
 		t.Fatalf("expecting AnEvent got %q", ev)
 	}
 
-	if !stream.HasNext() {
-		t.Fatalf("should have received event")
-	}
-	streamEvent = stream.WaitNext().(eventsourcing.Event)
-	switch ev := streamEvent.Data.(type) {
+	switch ev := streamEvents[1].Data.(type) {
 	case *AnEvent:
 		t.Fatalf("expecting OtherEvent got %q", ev)
 	}
@@ -72,52 +82,58 @@ func TestManySpecific(t *testing.T) {
 }
 
 func TestUpdateNoneSubscribedEvent(t *testing.T) {
+	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
-	stream := e.Subscribe(&AnotherEvent{})
+	f := func(e eventsourcing.Event) {
+		streamEvent = &e
+	}
+	e.Subscribe(f, &AnotherEvent{})
 	e.Update(event)
 
-	if stream.HasNext() {
-		t.Fatalf("should not have received event %q", stream.WaitNext())
+	if streamEvent != nil {
+		t.Fatalf("should not have received event %q", streamEvent)
 	}
 }
 
 func TestManySubscribers(t *testing.T) {
+	streamEvent1 := make([]eventsourcing.Event,0)
+	streamEvent2 := make([]eventsourcing.Event,0)
+	streamEvent3 := make([]eventsourcing.Event,0)
+	streamEvent4 := make([]eventsourcing.Event,0)
+
 	e := eventsourcing.NewEventStream()
-	stream1 := e.Subscribe(&AnotherEvent{})
-	stream2 := e.Subscribe(&AnotherEvent{}, &AnEvent{})
-	stream3 := e.Subscribe(&AnEvent{})
-	stream4 := e.Subscribe()
+	f1 := func(e eventsourcing.Event) {
+		streamEvent1 = append(streamEvent1,e)
+	}
+	f2 := func(e eventsourcing.Event) {
+		streamEvent2 = append(streamEvent2, e)
+	}
+	f3 := func(e eventsourcing.Event) {
+		streamEvent3 = append(streamEvent3, e)
+	}
+	f4 := func(e eventsourcing.Event) {
+		streamEvent4 = append(streamEvent4,e)
+	}
+	e.Subscribe(f1,&AnotherEvent{})
+	e.Subscribe(f2,&AnotherEvent{}, &AnEvent{})
+	e.Subscribe(f3,&AnEvent{})
+	e.Subscribe(f4)
 
 	e.Update(event)
 
-	if stream1.HasNext() {
+	if len(streamEvent1) != 0 {
 		t.Fatalf("stream1 should not have any events")
 	}
 
-	if !stream2.HasNext() {
+	if len(streamEvent2) != 1 {
 		t.Fatalf("stream2 should have one event")
-	} else {
-		stream2.Next()
-		if stream2.HasNext() {
-			t.Fatalf("stream2 should only have one event")
-		}
 	}
 
-	if !stream3.HasNext() {
+	if len(streamEvent3) != 1 {
 		t.Fatalf("stream3 should have one event")
-	} else {
-		stream3.Next()
-		if stream3.HasNext() {
-			t.Fatalf("stream3 should only have one event")
-		}
 	}
 
-	if !stream4.HasNext() {
+	if len(streamEvent4) != 1 {
 		t.Fatalf("stream4 should have one event")
-	} else {
-		stream4.Next()
-		if stream4.HasNext() {
-			t.Fatalf("stream4 should only have one event")
-		}
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -5,23 +5,30 @@ import (
 	"github.com/hallgren/eventsourcing"
 	"github.com/hallgren/eventsourcing/eventstore/memory"
 	"github.com/hallgren/eventsourcing/serializer/unsafe"
+	"github.com/imkira/go-observer"
 	"time"
 )
 
 func main() {
-
+	// go-observer to write and read events async
+	prop := observer.NewProperty(nil)
+	stream := prop.Observe()
 	// Setup a memory based event store
 	eventStore := memory.Create(unsafe.New())
 	repo := eventsourcing.NewRepository(eventStore, nil)
-	stream := repo.EventStream(nil)
+	f := func(e eventsourcing.Event) {
+		fmt.Printf("Event from stream %q\n", e)
+		// Its a good practice making this function as fast as possible not blocking the event sourcing call for to long
+		// Here we use the go-observer pkg to store the events in a stream to be consumed async
+		prop.Update(e)
+	}
+	repo.EventStream(f)
 
 	// Read the event stream async
 	go func() {
 		for {
-			<-stream.Changes()
 			// advance to next value
-			stream.Next()
-			event := stream.Value().(eventsourcing.Event)
+			event := stream.WaitNext().(eventsourcing.Event)
 			fmt.Println("STREAM EVENT")
 			fmt.Println(event)
 		}
@@ -48,5 +55,4 @@ func main() {
 	time.Sleep(time.Millisecond * 100)
 	fmt.Println("AGGREGATE")
 	fmt.Println(copy)
-
 }

--- a/example/main.go
+++ b/example/main.go
@@ -22,7 +22,7 @@ func main() {
 		// Here we use the go-observer pkg to store the events in a stream to be consumed async
 		prop.Update(e)
 	}
-	repo.EventStream(f)
+	repo.Subscribe(f)
 
 	// Read the event stream async
 	go func() {


### PR DESCRIPTION
Removes the go-observer pkg dependency with a call to registered function when events are saved to repository.

Where is nothing wrong with the go-observer pkg but it seams that it should be used outside this package if needed. This solution opens open a more generic way of handling real time events.