### PR TITLE
add lock to event stream to run subscribing func in sync with the events

### DIFF
--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -1,8 +1,9 @@
 package eventsourcing_test
 
 import (
-	"github.com/hallgren/eventsourcing"
 	"testing"
+
+	"github.com/hallgren/eventsourcing"
 )
 
 type AnEvent struct {
@@ -11,8 +12,8 @@ type AnEvent struct {
 
 type AnotherEvent struct{}
 
-var event = eventsourcing.Event{Version: 123, Data: &AnEvent{Name: "123"}}
-var otherEvent = eventsourcing.Event{Version: 123, Data: &AnotherEvent{}}
+var event = eventsourcing.Event{Version: 123, Data: &AnEvent{Name: "123"}, Reason: "AnEvent"}
+var otherEvent = eventsourcing.Event{Version: 123, Data: &AnotherEvent{}, Reason: "AnotherEvent"}
 
 func TestGlobal(t *testing.T) {
 	var streamEvent *eventsourcing.Event
@@ -21,7 +22,7 @@ func TestGlobal(t *testing.T) {
 		streamEvent = &e
 	}
 	e.Subscribe(f)
-	e.Update(event)
+	e.Update([]eventsourcing.Event{event})
 
 	//time.Sleep(1 * time.Second)
 	if streamEvent == nil {
@@ -32,15 +33,14 @@ func TestGlobal(t *testing.T) {
 	}
 }
 
-
 func TestSpecific(t *testing.T) {
 	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
 	f := func(e eventsourcing.Event) {
 		streamEvent = &e
 	}
-	e.Subscribe(f,&AnEvent{})
-	e.Update(event)
+	e.Subscribe(f, &AnEvent{})
+	e.Update([]eventsourcing.Event{event})
 
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
@@ -58,8 +58,8 @@ func TestManySpecific(t *testing.T) {
 		streamEvents = append(streamEvents, &e)
 	}
 	e.Subscribe(f, &AnEvent{}, &AnotherEvent{})
-	e.Update(event)
-	e.Update(otherEvent)
+	e.Update([]eventsourcing.Event{event})
+	e.Update([]eventsourcing.Event{otherEvent})
 
 	if streamEvents == nil {
 		t.Fatalf("should have received event")
@@ -88,7 +88,7 @@ func TestUpdateNoneSubscribedEvent(t *testing.T) {
 		streamEvent = &e
 	}
 	e.Subscribe(f, &AnotherEvent{})
-	e.Update(event)
+	e.Update([]eventsourcing.Event{event})
 
 	if streamEvent != nil {
 		t.Fatalf("should not have received event %q", streamEvent)
@@ -96,14 +96,14 @@ func TestUpdateNoneSubscribedEvent(t *testing.T) {
 }
 
 func TestManySubscribers(t *testing.T) {
-	streamEvent1 := make([]eventsourcing.Event,0)
-	streamEvent2 := make([]eventsourcing.Event,0)
-	streamEvent3 := make([]eventsourcing.Event,0)
-	streamEvent4 := make([]eventsourcing.Event,0)
+	streamEvent1 := make([]eventsourcing.Event, 0)
+	streamEvent2 := make([]eventsourcing.Event, 0)
+	streamEvent3 := make([]eventsourcing.Event, 0)
+	streamEvent4 := make([]eventsourcing.Event, 0)
 
 	e := eventsourcing.NewEventStream()
 	f1 := func(e eventsourcing.Event) {
-		streamEvent1 = append(streamEvent1,e)
+		streamEvent1 = append(streamEvent1, e)
 	}
 	f2 := func(e eventsourcing.Event) {
 		streamEvent2 = append(streamEvent2, e)
@@ -112,14 +112,14 @@ func TestManySubscribers(t *testing.T) {
 		streamEvent3 = append(streamEvent3, e)
 	}
 	f4 := func(e eventsourcing.Event) {
-		streamEvent4 = append(streamEvent4,e)
+		streamEvent4 = append(streamEvent4, e)
 	}
-	e.Subscribe(f1,&AnotherEvent{})
-	e.Subscribe(f2,&AnotherEvent{}, &AnEvent{})
-	e.Subscribe(f3,&AnEvent{})
+	e.Subscribe(f1, &AnotherEvent{})
+	e.Subscribe(f2, &AnotherEvent{}, &AnEvent{})
+	e.Subscribe(f3, &AnEvent{})
 	e.Subscribe(f4)
 
-	e.Update(event)
+	e.Update([]eventsourcing.Event{event})
 
 	if len(streamEvent1) != 0 {
 		t.Fatalf("stream1 should not have any events")
@@ -135,5 +135,43 @@ func TestManySubscribers(t *testing.T) {
 
 	if len(streamEvent4) != 1 {
 		t.Fatalf("stream4 should have one event")
+	}
+}
+
+func TestParallelUpdates(t *testing.T) {
+	streamEvent := make([]eventsourcing.Event, 0)
+	e := eventsourcing.NewEventStream()
+
+	// functions to bind to event subscription
+	f1 := func(e eventsourcing.Event) {
+		streamEvent = append(streamEvent, e)
+	}
+	f2 := func(e eventsourcing.Event) {
+		streamEvent = append(streamEvent, e)
+	}
+	f3 := func(e eventsourcing.Event) {
+		streamEvent = append(streamEvent, e)
+	}
+	e.Subscribe(f1, &AnEvent{})
+	e.Subscribe(f2, &AnotherEvent{})
+	e.Subscribe(f3)
+
+	// concurrently update the event stream
+	for i := 1; i < 1000; i++ {
+		go e.Update([]eventsourcing.Event{otherEvent, otherEvent})
+		go e.Update([]eventsourcing.Event{event, event})
+	}
+
+	var lastEvent eventsourcing.Event
+	// check that events comes coupled together in four due to the lock in the event stream that makes sure all registered
+	// functions are called together and that is not mixed with other events
+	for j, event := range streamEvent {
+		if j%4 == 0 {
+			lastEvent = event
+		} else {
+			if lastEvent.Reason != event.Reason {
+				t.Fatal("same event should come in couple of four")
+			}
+		}
 	}
 }

--- a/repository.go
+++ b/repository.go
@@ -52,18 +52,11 @@ func (r *Repository) Save(aggregate aggregate) error {
 	}
 
 	// publish the saved events to subscribers
-	// in async to make sure subscribers not blocks the call to Save
 	events := aggregate.changes()
-	go func() {
-		for _, event := range events {
-			r.eventStream.Update(event)
-		}
-	}()
-
+	r.eventStream.Update(events)
 
 	// aggregate are saved to the event store now its safe to update the internal aggregate state
 	aggregate.updateVersion()
-
 	return nil
 }
 

--- a/repository_test.go
+++ b/repository_test.go
@@ -112,7 +112,6 @@ func TestSaveSnapshotWithoutSnapshotStore(t *testing.T) {
 	}
 }
 
-
 func TestSubscription(t *testing.T) {
 	prop := observer.NewProperty(nil)
 	stream := prop.Observe()
@@ -159,4 +158,3 @@ outer:
 		t.Errorf("No global events was received from the stream, got %q", counter)
 	}
 }
-


### PR DESCRIPTION
take cares of possible concurrency problems between multiple event subscribers