### PR TITLE
Subscribe specific aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,16 +211,18 @@ The unsafe serializer stores the underlying memory representation of a struct di
 
 ### Event Subscription
 
-The repository expose three possibilities to subscribe to events in realtime as they are stored to the repository.
+The repository expose four possibilities to subscribe to events in realtime as they are saved to the repository.
 
 `SubscribeAll(func (e Event))` all event.
 
-`SubscribeAggregate(func (e Event), aggregates ...aggregate)` events bound to specific aggregates. 
+`SubscribeAggregateType(func (e Event), aggregates ...aggregate)` events bound to specific aggregate types. 
  
-`SubscribeSpecific(func (e Event), events ...interface{})` specific events. There is no restrictions that the events need
+`SubscribeSpecificEvent(func (e Event), events ...interface{})` specific events. There is no restrictions that the events need
 to come from the same aggregate, you can mix and match as you please.
 
-The subscription is realtime and events that are saved before the call to the Subscribe function will not be exposed via the `func(e Event)` function. If the application 
+`SubscribeSpecificAggregate(func (e Event), events ...aggregate)` events bound to specific aggregate based on type and identity. This makes it possible to get events pinpointed to one specific aggregate instance. 
+
+The subscription is realtime and events that are saved before the call to one of the subscribers will not be exposed via the `func(e Event)` function. If the application 
 depends on this functionality make sure to call the subscribe function before any events are saved. 
 
 The event subscription enables the application to make use of the reactive patterns and to make it more decoupled. Check out the [Reactive Manifesto](https://www.reactivemanifesto.org/) 

--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -52,12 +52,12 @@ func (state *AggregateRoot) TrackChangeWithMetaData(a aggregate, data interface{
 	}
 
 	reason := reflect.TypeOf(data).Elem().Name()
-	aggregateType := reflect.TypeOf(a).Elem().Name()
+	name := reflect.TypeOf(a).Elem().Name()
 	event := Event{
 		AggregateRootID: state.AggregateID,
 		Version:         state.nextVersion(),
 		Reason:          reason,
-		AggregateType:   aggregateType,
+		AggregateType:   name,
 		Timestamp:       time.Now().UTC(),
 		Data:            data,
 		MetaData:        metaData,
@@ -114,9 +114,15 @@ func (state *AggregateRoot) SetID(id string) error {
 	return nil
 }
 
-// ID returns the aggregate id as a string
+// id returns the aggregate id as a string
 func (state *AggregateRoot) id() string {
 	return state.AggregateID
+}
+
+// path return the full name of the aggregate making it unique to other aggregates with
+// the same name but placed in other packages.
+func (state *AggregateRoot) path() string {
+	return reflect.TypeOf(state).Elem().PkgPath()
 }
 
 // CurrentVersion return the version based on events that are not stored

--- a/eventstream.go
+++ b/eventstream.go
@@ -73,8 +73,8 @@ func (e *EventStream) SubscribeAggregateTypes(f func(e Event), aggregates ...agg
 	}
 }
 
-// SubscribeSpecificEvents bind the f function to be called on specific events
-func (e *EventStream) SubscribeSpecificEvents(f func(e Event), events ...interface{}) {
+// SubscribeSpecificEvent bind the f function to be called on specific events
+func (e *EventStream) SubscribeSpecificEvent(f func(e Event), events ...interface{}) {
 	// subscribe to specified events
 	for _, event := range events {
 		t := reflect.TypeOf(event)

--- a/eventstream.go
+++ b/eventstream.go
@@ -75,8 +75,7 @@ func (e *EventStream) SubscribeAll(f func(e Event)) {
 func (e *EventStream) SubscribeSpecificAggregate(f func(e Event), aggregates ...aggregate) {
 	for _, a := range aggregates {
 		aggregateType := reflect.TypeOf(a).Elem().Name()
-		id := a.id()
-		ref := fmt.Sprintf("%s_%s", aggregateType, id)
+		ref := fmt.Sprintf("%s_%s", aggregateType, a.id())
 		if e.aggregateTypes[ref] == nil {
 			// add the name and id of the aggregate and function to call to the empty register key
 			e.aggregateTypes[ref] = []func(e Event){f}

--- a/eventstream.go
+++ b/eventstream.go
@@ -52,7 +52,7 @@ func (e *EventStream) Update(events []Event) {
 
 		// call all functions that has registered for the aggregate type and id events
 		ref := fmt.Sprintf("%s_%s", event.AggregateType, event.AggregateRootID)
-		if functions, ok := e.aggregateTypes[ref]; ok {
+		if functions, ok := e.specificAggregates[ref]; ok {
 			for _, f := range functions {
 				f(event)
 			}
@@ -76,12 +76,12 @@ func (e *EventStream) SubscribeSpecificAggregate(f func(e Event), aggregates ...
 	for _, a := range aggregates {
 		aggregateType := reflect.TypeOf(a).Elem().Name()
 		ref := fmt.Sprintf("%s_%s", aggregateType, a.id())
-		if e.aggregateTypes[ref] == nil {
+		if e.specificAggregates[ref] == nil {
 			// add the name and id of the aggregate and function to call to the empty register key
-			e.aggregateTypes[ref] = []func(e Event){f}
+			e.specificAggregates[ref] = []func(e Event){f}
 		} else {
 			// adds one more function to the aggregate
-			e.aggregateTypes[ref] = append(e.aggregateTypes[ref], f)
+			e.specificAggregates[ref] = append(e.specificAggregates[ref], f)
 		}
 	}
 }

--- a/eventstream.go
+++ b/eventstream.go
@@ -55,8 +55,8 @@ func (e *EventStream) SubscribeAll(f func(e Event)) {
 	e.allEvents = append(e.allEvents, f)
 }
 
-// SubscribeAggregate bind the f function to be called on events on the aggregate type
-func (e *EventStream) SubscribeAggregate(f func(e Event), aggregates ...aggregate) {
+// SubscribeAggregateTypes bind the f function to be called on events on the aggregate type
+func (e *EventStream) SubscribeAggregateTypes(f func(e Event), aggregates ...aggregate) {
 	for _, a := range aggregates {
 		aggregateType := reflect.TypeOf(a).Elem().Name()
 		if e.aggregateEvents[aggregateType] == nil {
@@ -69,8 +69,8 @@ func (e *EventStream) SubscribeAggregate(f func(e Event), aggregates ...aggregat
 	}
 }
 
-// SubscribeSpecific bind the f function to be called on specific events
-func (e *EventStream) SubscribeSpecific(f func(e Event), events ...interface{}) {
+// SubscribeSpecificEvents bind the f function to be called on specific events
+func (e *EventStream) SubscribeSpecificEvents(f func(e Event), events ...interface{}) {
 	// subscribe to specified events
 	for _, event := range events {
 		t := reflect.TypeOf(event)

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -45,13 +45,13 @@ func TestAll(t *testing.T) {
 	}
 }
 
-func TestSpecific(t *testing.T) {
+func TestSubscribeOneEvent(t *testing.T) {
 	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
 	f := func(e eventsourcing.Event) {
 		streamEvent = &e
 	}
-	e.SubscribeSpecific(f, &AnEvent{})
+	e.SubscribeSpecificEvents(f, &AnEvent{})
 	e.Update([]eventsourcing.Event{event})
 
 	if streamEvent == nil {
@@ -63,13 +63,13 @@ func TestSpecific(t *testing.T) {
 	}
 }
 
-func TestSubscribeAggregate(t *testing.T) {
+func TestSubscribeAggregateType(t *testing.T) {
 	var streamEvent *eventsourcing.Event
 	e := eventsourcing.NewEventStream()
 	f := func(e eventsourcing.Event) {
 		streamEvent = &e
 	}
-	e.SubscribeAggregate(f, &AnAggregate{}, &AnotherAggregate{})
+	e.SubscribeAggregateTypes(f, &AnAggregate{}, &AnotherAggregate{})
 
 	// update with event from the AnAggregate aggregate
 	e.Update([]eventsourcing.Event{event})
@@ -87,13 +87,13 @@ func TestSubscribeAggregate(t *testing.T) {
 	}
 }
 
-func TestManySpecific(t *testing.T) {
+func TestSubscribeToManyEvents(t *testing.T) {
 	var streamEvents []*eventsourcing.Event
 	e := eventsourcing.NewEventStream()
 	f := func(e eventsourcing.Event) {
 		streamEvents = append(streamEvents, &e)
 	}
-	e.SubscribeSpecific(f, &AnEvent{}, &AnotherEvent{})
+	e.SubscribeSpecificEvents(f, &AnEvent{}, &AnotherEvent{})
 	e.Update([]eventsourcing.Event{event})
 	e.Update([]eventsourcing.Event{otherEvent})
 
@@ -123,7 +123,7 @@ func TestUpdateNoneSubscribedEvent(t *testing.T) {
 	f := func(e eventsourcing.Event) {
 		streamEvent = &e
 	}
-	e.SubscribeSpecific(f, &AnotherEvent{})
+	e.SubscribeSpecificEvents(f, &AnotherEvent{})
 	e.Update([]eventsourcing.Event{event})
 
 	if streamEvent != nil {
@@ -154,11 +154,11 @@ func TestManySubscribers(t *testing.T) {
 	f5 := func(e eventsourcing.Event) {
 		streamEvent5 = append(streamEvent5, e)
 	}
-	e.SubscribeSpecific(f1, &AnotherEvent{})
-	e.SubscribeSpecific(f2, &AnotherEvent{}, &AnEvent{})
-	e.SubscribeSpecific(f3, &AnEvent{})
+	e.SubscribeSpecificEvents(f1, &AnotherEvent{})
+	e.SubscribeSpecificEvents(f2, &AnotherEvent{}, &AnEvent{})
+	e.SubscribeSpecificEvents(f3, &AnEvent{})
 	e.SubscribeAll(f4)
-	e.SubscribeAggregate(f5, &AnAggregate{})
+	e.SubscribeAggregateTypes(f5, &AnAggregate{})
 
 	e.Update([]eventsourcing.Event{event})
 
@@ -197,8 +197,8 @@ func TestParallelUpdates(t *testing.T) {
 	f3 := func(e eventsourcing.Event) {
 		streamEvent = append(streamEvent, e)
 	}
-	e.SubscribeSpecific(f1, &AnEvent{})
-	e.SubscribeSpecific(f2, &AnotherEvent{})
+	e.SubscribeSpecificEvents(f1, &AnEvent{})
+	e.SubscribeSpecificEvents(f2, &AnotherEvent{})
 	e.SubscribeAll(f3)
 
 	wg := sync.WaitGroup{}

--- a/repository.go
+++ b/repository.go
@@ -53,7 +53,7 @@ func (r *Repository) Save(aggregate aggregate) error {
 
 	// publish the saved events to subscribers
 	events := aggregate.changes()
-	r.eventStream.Update(events)
+	r.eventStream.Update(aggregate, events)
 
 	// aggregate are saved to the event store now its safe to update the internal aggregate state
 	aggregate.updateVersion()

--- a/repository.go
+++ b/repository.go
@@ -108,7 +108,7 @@ func (r *Repository) SubscribeAll(f func(e Event)) {
 
 // SubscribeSpecificEvents binds the input func f to be called when supplied events are saved.
 func (r *Repository) SubscribeSpecificEvents(f func(e Event), events ...interface{}) {
-	r.eventStream.SubscribeSpecificEvents(f, events...)
+	r.eventStream.SubscribeSpecificEvent(f, events...)
 }
 
 // SubscribeAggregateType binds the input func f to be called on all events bound to supplied aggregates

--- a/repository.go
+++ b/repository.go
@@ -21,6 +21,7 @@ type snapshotStore interface {
 // aggregate interface to use the aggregate root specific methods
 type aggregate interface {
 	id() string
+	path() string
 	BuildFromHistory(a aggregate, events []Event)
 	Transition(event Event)
 	changes() []Event

--- a/repository.go
+++ b/repository.go
@@ -111,7 +111,12 @@ func (r *Repository) SubscribeSpecificEvents(f func(e Event), events ...interfac
 	r.eventStream.SubscribeSpecificEvent(f, events...)
 }
 
-// SubscribeAggregateType binds the input func f to be called on all events bound to supplied aggregates
+// SubscribeAggregateType binds the input func f to be called on all events bound to supplied aggregates by type
 func (r *Repository) SubscribeAggregateType(f func(e Event), aggregates ...aggregate) {
 	r.eventStream.SubscribeAggregateTypes(f, aggregates...)
+}
+
+// SubscribeSpecificAggregate binds the input func f to be called on all events bound to supplied aggregates by type and identifier
+func (r *Repository) SubscribeSpecificAggregate(f func(e Event), aggregates ...aggregate) {
+	r.eventStream.SubscribeSpecificAggregate(f, aggregates...)
 }

--- a/repository.go
+++ b/repository.go
@@ -106,12 +106,12 @@ func (r *Repository) SubscribeAll(f func(e Event)) {
 	r.eventStream.SubscribeAll(f)
 }
 
-// SubscribeSpecific binds the input func f to be called when supplied events are saved.
-func (r *Repository) SubscribeSpecific(f func(e Event), events ...interface{}) {
-	r.eventStream.SubscribeSpecific(f, events...)
+// SubscribeSpecificEvents binds the input func f to be called when supplied events are saved.
+func (r *Repository) SubscribeSpecificEvents(f func(e Event), events ...interface{}) {
+	r.eventStream.SubscribeSpecificEvents(f, events...)
 }
 
-// SubscribeAggregate binds the input func f to be called on all events bound to supplied aggregates
-func (r *Repository) SubscribeAggregate(f func(e Event), aggregates ...aggregate) {
-	r.eventStream.SubscribeAggregate(f, aggregates...)
+// SubscribeAggregateType binds the input func f to be called on all events bound to supplied aggregates
+func (r *Repository) SubscribeAggregateType(f func(e Event), aggregates ...aggregate) {
+	r.eventStream.SubscribeAggregateTypes(f, aggregates...)
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -145,7 +145,7 @@ func TestSubscriptionSpecific(t *testing.T) {
 	serializer := json.New()
 	serializer.Register(&Person{}, &Born{}, &AgedOneYear{})
 	repo := eventsourcing.NewRepository(memory.Create(serializer), nil)
-	repo.SubscribeSpecific(f, &Born{}, &AgedOneYear{})
+	repo.SubscribeSpecificEvents(f, &Born{}, &AgedOneYear{})
 
 	person, err := CreatePerson("kalle")
 	if err != nil {
@@ -172,7 +172,7 @@ func TestSubscriptionAggregate(t *testing.T) {
 	serializer := json.New()
 	serializer.Register(&Person{}, &Born{}, &AgedOneYear{})
 	repo := eventsourcing.NewRepository(memory.Create(serializer), nil)
-	repo.SubscribeAggregate(f, &Person{})
+	repo.SubscribeAggregateType(f, &Person{})
 
 	person, err := CreatePerson("kalle")
 	if err != nil {


### PR DESCRIPTION
Makes it possible to subscribe to events from a specific aggregate instance. Based on aggregate type and identity.