### PR TITLE
Aggregate interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,17 +114,17 @@ The repository is used to save and retrieve aggregates. The main functions are:
 
 ```go
 // saves the events on the aggregate
-Save(aggregate aggregate) error
+Save(aggregate Aggregate) error
 
 // retrieves and build an aggregate from events based on its identifier
-Get(id string, aggregate aggregate) error
+Get(id string, aggregate Aggregate) error
 ```
 
 It is possible to save a snapshot of an aggregate reducing the amount of event needed to be fetched and applied.
 
 ```go
 // saves the aggregate (an error will be returned if there are unsaved events on the aggregate when doing this operation)
-SaveSnapshot(aggregate aggregate) error
+SaveSnapshot(aggregate Aggregate) error
 ```
 
 The repository constructor input values is an event store and a snapshot store, this handles the reading and writing of events and snapshots. We will dig deeper on the internals below.
@@ -202,7 +202,7 @@ serializer := NewSerializer(json.Marshal, json.Unmarshal)
 The registered event function is used internally inside the event store to set the correct type info when unmarshalling
 event data into the `eventsourcing.Event`.
 ```go
-RegisterTypes(aggregate aggregate, events ...func() interface{})
+RegisterTypes(aggregate Aggregate, events ...func() interface{})
 
 register the aggregate Person and the event Born:
 serializer.RegisterTypes(&Person{}, func() interface{} { return &Born{}})
@@ -214,12 +214,12 @@ The repository expose four possibilities to subscribe to events in realtime as t
 
 `SubscriberAll(func (e Event)) *Subscription` all event.
 
-`SubscriberAggregateType(func (e Event), aggregates ...aggregate) *Subscription` events bound to specific aggregate types. 
+`SubscriberAggregateType(func (e Event), aggregates ...Aggregate) *Subscription` events bound to specific aggregate types. 
  
 `SubscriberSpecificEvent(func (e Event), events ...interface{}) *Subscription` specific events. There are no restrictions that the events need
 to come from the same aggregate, you can mix and match as you please.
 
-`SubscriberSpecificAggregate(func (e Event), events ...aggregate) *Subscription` events bound to specific aggregate based on type and identity. This makes it possible to get events pinpointed to one specific aggregate instance. 
+`SubscriberSpecificAggregate(func (e Event), events ...Aggregate) *Subscription` events bound to specific aggregate based on type and identity. This makes it possible to get events pinpointed to one specific aggregate instance. 
 
 The subscription is realtime and events that are saved before the call to one of the subscribers will not be exposed via the `func(e Event)` function. If the application 
 depends on this functionality make sure to call Subscribe() function on the subscriber before storing events in the repository. 

--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"time"
 
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 )
 
 // Version is the event version used in event and aggregateRoot

--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -40,14 +40,14 @@ const (
 
 // TrackChange is used internally by behaviour methods to apply a state change to
 // the current instance and also track it in order that it can be persisted later.
-func (state *AggregateRoot) TrackChange(a aggregate, data interface{}) {
+func (state *AggregateRoot) TrackChange(a Aggregate, data interface{}) {
 	state.TrackChangeWithMetaData(a, data, nil)
 }
 
 // TrackChangeWithMetaData is used internally by behaviour methods to apply a state change to
 // the current instance and also track it in order that it can be persisted later.
 // meta data is handled by this func to store none related application state
-func (state *AggregateRoot) TrackChangeWithMetaData(a aggregate, data interface{}, metaData map[string]interface{}) {
+func (state *AggregateRoot) TrackChangeWithMetaData(a Aggregate, data interface{}, metaData map[string]interface{}) {
 	// This can be overwritten in the constructor of the aggregate
 	if state.AggregateID == emptyAggregateID {
 		state.AggregateID = uuid.New().String()
@@ -69,7 +69,7 @@ func (state *AggregateRoot) TrackChangeWithMetaData(a aggregate, data interface{
 }
 
 // BuildFromHistory builds the aggregate state from events
-func (state *AggregateRoot) BuildFromHistory(a aggregate, events []Event) {
+func (state *AggregateRoot) BuildFromHistory(a Aggregate, events []Event) {
 	for _, event := range events {
 		a.Transition(event)
 		//Set the aggregate ID
@@ -92,7 +92,13 @@ func (state *AggregateRoot) updateVersion() {
 	}
 }
 
-//Public accessors for aggregate root properties
+// path return the full name of the aggregate making it unique to other aggregates with
+// the same name but placed in other packages.
+func (state *AggregateRoot) path() string {
+	return reflect.TypeOf(state).Elem().PkgPath()
+}
+
+//Public accessors for aggregate Root properties
 
 // SetID opens up the possibility to set manual aggregate ID from the outside
 func (state *AggregateRoot) SetID(id string) error {
@@ -108,10 +114,9 @@ func (state *AggregateRoot) ID() string {
 	return state.AggregateID
 }
 
-// path return the full name of the aggregate making it unique to other aggregates with
-// the same name but placed in other packages.
-func (state *AggregateRoot) path() string {
-	return reflect.TypeOf(state).Elem().PkgPath()
+// Root returns the included Aggregate Root state, and is used from the interface Aggregate.
+func (state *AggregateRoot) Root() *AggregateRoot {
+	return state
 }
 
 // Version return the version based on events that are not stored

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -37,7 +37,7 @@ func TestAll(t *testing.T) {
 	s := e.SubscriberAll(f)
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
@@ -56,7 +56,7 @@ func TestSubscribeOneEvent(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
@@ -84,7 +84,7 @@ func TestSubscriberSpecificAggregate(t *testing.T) {
 	s.Subscribe()
 	defer s.Unsubscribe()
 	// update with event from the AnAggregate aggregate
-	e.Update(&anAggregate, []eventsourcing.Event{event})
+	e.Update(anAggregate.AggregateRoot, []eventsourcing.Event{event})
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
@@ -93,7 +93,7 @@ func TestSubscriberSpecificAggregate(t *testing.T) {
 	}
 
 	// update with event from the AnotherAggregate aggregate
-	e.Update(&anOtherAggregate, []eventsourcing.Event{otherEvent})
+	e.Update(anOtherAggregate.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != otherEvent.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, otherEvent.Version)
 	}
@@ -110,7 +110,7 @@ func TestSubscribeAggregateType(t *testing.T) {
 	defer s.Unsubscribe()
 
 	// update with event from the AnAggregate aggregate
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
@@ -119,7 +119,7 @@ func TestSubscribeAggregateType(t *testing.T) {
 	}
 
 	// update with event from the AnotherAggregate aggregate
-	e.Update(&AnotherAggregate{}, []eventsourcing.Event{otherEvent})
+	e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != otherEvent.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, otherEvent.Version)
 	}
@@ -134,8 +134,8 @@ func TestSubscribeToManyEvents(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnEvent{}, &AnotherEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
-	e.Update(&AnotherAggregate{}, []eventsourcing.Event{otherEvent})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 
 	if streamEvents == nil {
 		t.Fatalf("should have received event")
@@ -166,7 +166,7 @@ func TestUpdateNoneSubscribedEvent(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnotherEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent != nil {
 		t.Fatalf("should not have received event %q", streamEvent)
@@ -212,7 +212,7 @@ func TestManySubscribers(t *testing.T) {
 	s.Subscribe()
 	defer s.Unsubscribe()
 
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if len(streamEvent1) != 0 {
 		t.Fatalf("stream1 should not have any events")
@@ -261,11 +261,11 @@ func TestParallelUpdates(t *testing.T) {
 	for i := 1; i < 1000; i++ {
 		wg.Add(2)
 		go func() {
-			e.Update(&AnotherAggregate{}, []eventsourcing.Event{otherEvent, otherEvent})
+			e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent, otherEvent})
 			wg.Done()
 		}()
 		go func() {
-			e.Update(&AnAggregate{}, []eventsourcing.Event{event, event})
+			e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event, event})
 			wg.Done()
 		}()
 	}
@@ -301,7 +301,7 @@ func TestClose(t *testing.T) {
 	s4.Subscribe()
 
 	// trigger all 4 subscriptions
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if count != 4 {
 		t.Fatalf("should have received four event")
 	}
@@ -312,7 +312,7 @@ func TestClose(t *testing.T) {
 	s4.Unsubscribe()
 
 	// new event should not trigger closed subscriptions
-	e.Update(&AnAggregate{}, []eventsourcing.Event{event})
+	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if count != 4 {
 		t.Fatalf("should not have received event after subscriptions are closed")
 	}

--- a/serializer.go
+++ b/serializer.go
@@ -37,7 +37,7 @@ var (
 )
 
 // RegisterTypes events aggregate
-func (h *Serializer) RegisterTypes(aggregate aggregate, events ...eventFunc) error {
+func (h *Serializer) RegisterTypes(aggregate Aggregate, events ...eventFunc) error {
 	typ := reflect.TypeOf(aggregate).Elem().Name()
 	if typ == "" {
 		return ErrAggregateNameMissing

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -20,7 +20,7 @@ func initSerializers(t *testing.T) []*eventsourcing.Serializer {
 	return result
 }
 
-type SomeAggregate struct{
+type SomeAggregate struct {
 	eventsourcing.AggregateRoot
 }
 

--- a/snapshotstore/memory.go
+++ b/snapshotstore/memory.go
@@ -20,7 +20,7 @@ func New(serializer eventsourcing.Serializer) *Handler {
 }
 
 // Get returns the deserialize snapshot
-func (h *Handler) Get(id string, s eventsourcing.Snapshot) error {
+func (h *Handler) Get(id string, s eventsourcing.Aggregate) error {
 	v, ok := h.store[id]
 	if !ok {
 		return eventsourcing.ErrSnapshotNotFound
@@ -33,17 +33,18 @@ func (h *Handler) Get(id string, s eventsourcing.Snapshot) error {
 }
 
 // Save persists the snapshot
-func (h *Handler) Save(s eventsourcing.Snapshot) error {
-	if s.ID() == "" {
+func (h *Handler) Save(s eventsourcing.Aggregate) error {
+	root := s.Root()
+	if root.ID() == "" {
 		return errors.New("aggregate id is empty")
 	}
-	if s.UnsavedEvents() {
+	if root.UnsavedEvents() {
 		return errors.New("aggregate holds unsaved events")
 	}
 	data, err := h.serializer.Marshal(s)
 	if err != nil {
 		return err
 	}
-	h.store[s.ID()] = data
+	h.store[root.ID()] = data
 	return nil
 }


### PR DESCRIPTION
Exported the Aggregate interface and reduced the methods from ->

```go
type aggregate interface {
	ID() string
	path() string	
	BuildFromHistory(a aggregate, events []Event)	
	Transition(event Event)
	Events() []Event	
	UnsavedEvents() bool	
	updateVersion()	
	Version() Version	
	SetID(id string) error	
}
```
to
```go
type Aggregate interface {
	Root() *AggregateRoot
	Transition(event Event)
}
```
where the Root() method return a pointer to the internal AggregateRoot struct.