### PR TITLE
Removed all external dependencies from the main eventsourcing pkg

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ type Event struct {
 }
 ```
 
+### Aggregate ID
+
+The identifier on the aggregate is default set by a random generated string via the crypt/rand pkg. It is possible to change the default behaivior in two ways.
+
+* Set a specific id on the aggregate via the SetID func.
+
+```go
+var id = "123"
+person := Person{}
+err := person.SetID(id)
+```
+
+* Change the id generator via the global eventsourcing.SetIDFunc function.
+
+```go
+var counter = 0
+f := func() string {
+	counter++
+	return fmt.Sprint(counter)
+}
+
+eventsourcing.SetIDFunc(f)
+```
+
 ## Repository
 
 The repository is used to save and retrieve aggregates. The main functions are:

--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -2,7 +2,6 @@ package eventsourcing
 
 import (
 	"errors"
-	"math/rand"
 	"reflect"
 	"time"
 )
@@ -41,22 +40,6 @@ const (
 // the current instance and also track it in order that it can be persisted later.
 func (state *AggregateRoot) TrackChange(a Aggregate, data interface{}) {
 	state.TrackChangeWithMetaData(a, data, nil)
-}
-
-func randSeq() string {
-	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-
-	b := make([]rune, 10)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
-}
-
-var idFunc = randSeq
-
-func SetIDFunc(f func() string) {
-	idFunc = f
 }
 
 // TrackChangeWithMetaData is used internally by behaviour methods to apply a state change to

--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -2,10 +2,9 @@ package eventsourcing
 
 import (
 	"errors"
+	"math/rand"
 	"reflect"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // Version is the event version used in event and aggregateRoot
@@ -44,13 +43,29 @@ func (state *AggregateRoot) TrackChange(a Aggregate, data interface{}) {
 	state.TrackChangeWithMetaData(a, data, nil)
 }
 
+func randSeq() string {
+	var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+	b := make([]rune, 10)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}
+
+var idFunc = randSeq
+
+func SetIDFunc(f func() string) {
+	idFunc = f
+}
+
 // TrackChangeWithMetaData is used internally by behaviour methods to apply a state change to
 // the current instance and also track it in order that it can be persisted later.
 // meta data is handled by this func to store none related application state
 func (state *AggregateRoot) TrackChangeWithMetaData(a Aggregate, data interface{}, metaData map[string]interface{}) {
 	// This can be overwritten in the constructor of the aggregate
 	if state.AggregateID == emptyAggregateID {
-		state.AggregateID = uuid.New().String()
+		state.AggregateID = idFunc()
 	}
 
 	reason := reflect.TypeOf(data).Elem().Name()

--- a/eventsourcing_test.go
+++ b/eventsourcing_test.go
@@ -177,11 +177,24 @@ func TestSetIDFunc(t *testing.T) {
 		counter++
 		return fmt.Sprint(counter)
 	}
+
 	eventsourcing.SetIDFunc(f)
 	for i := 1; i< 10; i++ {
 		person, _ := CreatePerson("kalle")
 		if person.ID() != fmt.Sprint(i) {
 			t.Fatalf("id not set via the new SetIDFunc, exp: %d got: %s",i, person.ID())
 		}
+	}
+}
+
+func TestIDFuncGeneratingRandomIDs(t *testing.T) {
+	var ids = map[string]struct{}{}
+	for i := 1; i< 100000; i++ {
+		person, _ := CreatePerson("kalle")
+		_, exists := ids[person.ID()]
+		if exists {
+			t.Fatalf("id: %s, already created", person.ID())
+		}
+		ids[person.ID()] = struct{}{}
 	}
 }

--- a/eventsourcing_test.go
+++ b/eventsourcing_test.go
@@ -2,6 +2,7 @@ package eventsourcing_test
 
 import (
 	"errors"
+	"fmt"
 	"github.com/hallgren/eventsourcing"
 	"testing"
 	"time"
@@ -167,5 +168,20 @@ func TestPersonGrewTenYears(t *testing.T) {
 
 	if person.Age != 10 {
 		t.Fatal("person has the wrong Age")
+	}
+}
+
+func TestSetIDFunc(t *testing.T) {
+	var counter = 0
+	f := func() string {
+		counter++
+		return fmt.Sprint(counter)
+	}
+	eventsourcing.SetIDFunc(f)
+	for i := 1; i< 10; i++ {
+		person, _ := CreatePerson("kalle")
+		if person.ID() != fmt.Sprint(i) {
+			t.Fatalf("id not set via the new SetIDFunc, exp: %d got: %s",i, person.ID())
+		}
 	}
 }

--- a/example/main.go
+++ b/example/main.go
@@ -15,7 +15,7 @@ func main() {
 	f := func(e eventsourcing.Event) {
 		fmt.Printf("Event from stream %q\n", e)
 		// Its a good practice making this function as fast as possible not blocking the event sourcing call for to long
-		// Here we use the go-observer pkg to store the events in a stream to be consumed async
+		// Here we use a channel to store the events to be consumed async
 		c <- e
 	}
 	sub := repo.SubscriberAll(f)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,3 @@
 module github.com/hallgren/eventsourcing
 
 go 1.13
-
-require (
-	github.com/google/uuid v1.1.2
-)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,0 @@
-github.com/go-gorp/gorp v2.0.0+incompatible/go.mod h1:7IfkAQnO7jfT/9IQ3R9wL1dFhukN6aQxzKTHnkxzA/E=
-github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
-github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244 h1:fdX2U+a2Rmc4BjRYcOKzjYXtYTE4ga1B2lb8i7BlefU=
-github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244/go.mod h1:jG8oAQG0ZPHPyxg5QlMERS31airDC+ZuqiAe8DUvFVo=

--- a/idgenerator.go
+++ b/idgenerator.go
@@ -35,9 +35,5 @@ func generateRandomString(n int) (string, error) {
 func generateRandomBytes(n int) ([]byte, error) {
 	b := make([]byte, n)
 	_, err := rand.Read(b)
-	// Note that err == nil only if we read len(b) bytes.
-	if err != nil {
-		return nil, err
-	}
-	return b, nil
+	return b, err
 }

--- a/idgenerator.go
+++ b/idgenerator.go
@@ -1,6 +1,8 @@
 package eventsourcing
 
-import "crypto/rand"
+import (
+	"crypto/rand"
+)
 
 // idFunc is a global function that generates aggregate id's.
 // It could be changed from the outside via the SetIDFunc function.
@@ -13,7 +15,7 @@ func SetIDFunc(f func() string) {
 }
 
 func randSeq() string {
-	id, err := generateRandomString(32)
+	id, err := generateRandomString(20)
 	if err != nil {
 		return ""
 	}

--- a/idgenerator.go
+++ b/idgenerator.go
@@ -1,0 +1,43 @@
+package eventsourcing
+
+import "crypto/rand"
+
+// idFunc is a global function that generates aggregate id's.
+// It could be changed from the outside via the SetIDFunc function.
+var idFunc = randSeq
+
+// SetIDFunc is used to change how aggregate ID's are generated
+// default is a random string
+func SetIDFunc(f func() string) {
+	idFunc = f
+}
+
+func randSeq() string {
+	id, err := generateRandomString(32)
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
+func generateRandomString(n int) (string, error) {
+	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+	bytes, err := generateRandomBytes(n)
+	if err != nil {
+		return "", err
+	}
+	for i, b := range bytes {
+		bytes[i] = letters[b%byte(len(letters))]
+	}
+	return string(bytes), nil
+}
+
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return nil, err
+	}
+	return b, nil
+}


### PR DESCRIPTION
Aggregate ID's are by default generated via the crypt/rand pkg instead of a external uuid pkg.

This could be changed via the global SetIDFunc.