### PR TITLE
return ErrNoEvents when no events for an aggregate

### DIFF
--- a/eventsourcing.go
+++ b/eventsourcing.go
@@ -30,6 +30,10 @@ type Event struct {
 var (
 	// ErrAggregateAlreadyExists returned if the AggregateID is set more than one time
 	ErrAggregateAlreadyExists = errors.New("its not possible to set ID on already existing aggregate")
+
+	// ErrNoEvents when there is no events to get
+	ErrNoEvents = errors.New("no events")
+
 )
 
 const (

--- a/eventstore/bbolt/bbolt.go
+++ b/eventstore/bbolt/bbolt.go
@@ -15,9 +15,6 @@ const (
 	globalEventOrderBucketName = "global_event_order"
 )
 
-// ErrorNotFound is returned when a given entity cannot be found in the event stream
-var ErrorNotFound = errors.New("NotFoundError")
-
 // itob returns an 8-byte big endian representation of v.
 func itob(v uint64) []byte {
 	b := make([]byte, 8)
@@ -177,6 +174,9 @@ func (e *BBolt) Get(id string, aggregateType string, afterVersion eventsourcing.
 	defer tx.Rollback()
 
 	evBucket := tx.Bucket([]byte(bucketName))
+	if evBucket == nil {
+		return nil, eventsourcing.ErrNoEvents
+	}
 
 	cursor := evBucket.Cursor()
 	events := make([]eventsourcing.Event, 0)
@@ -208,6 +208,9 @@ func (e *BBolt) Get(id string, aggregateType string, afterVersion eventsourcing.
 			Data:          eventData,
 		}
 		events = append(events, event)
+	}
+	if len(events) == 0 {
+		return nil, eventsourcing.ErrNoEvents
 	}
 	return events, nil
 }

--- a/eventstore/bbolt/go.mod
+++ b/eventstore/bbolt/go.mod
@@ -6,3 +6,7 @@ require (
 	github.com/hallgren/eventsourcing v0.0.14
 	go.etcd.io/bbolt v1.3.4
 )
+
+replace (
+	github.com/hallgren/eventsourcing => ../..
+)

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -80,7 +80,9 @@ func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing
 		if e.Version > afterVersion {
 			events = append(events, e)
 		}
-
+	}
+	if len(events) == 0 {
+		return nil, eventsourcing.ErrNoEvents
 	}
 	return events, nil
 }

--- a/eventstore/sql/go.mod
+++ b/eventstore/sql/go.mod
@@ -6,3 +6,7 @@ require (
 	github.com/hallgren/eventsourcing v0.0.14
 	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244
 )
+
+replace (
+	github.com/hallgren/eventsourcing => ../..
+)

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -88,7 +88,8 @@ func (s *SQL) Save(events []eventsourcing.Event) error {
 }
 
 // Get the events from database
-func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (events []eventsourcing.Event, err error) {
+func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error) {
+	var events []eventsourcing.Event
 	selectStm := `Select id, version, reason, type, timestamp, data, metadata from events where id=? and type=? and version>? order by version asc`
 	rows, err := s.db.Query(selectStm, id, aggregateType, afterVersion)
 	if err != nil {
@@ -137,5 +138,8 @@ func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Ve
 			MetaData:      eventMetaData,
 		})
 	}
-	return
+	if len(events) == 0 {
+		return nil, eventsourcing.ErrNoEvents
+	}
+	return events, nil
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -38,6 +38,16 @@ func TestSaveAndGetAggregate(t *testing.T) {
 	}
 }
 
+func TestGetNoneExistingAggregate(t *testing.T) {
+	repo := eventsourcing.NewRepository(memory.Create(), nil)
+
+	p := Person{}
+	err := repo.Get("none_existing", &p)
+	if err != eventsourcing.ErrAggregateNotFound {
+		t.Fatal("could not get aggregate")
+	}
+}
+
 func TestSaveAndGetAggregateSnapshotAndEvents(t *testing.T) {
 	ser := eventsourcing.NewSerializer(xml.Marshal, xml.Unmarshal)
 	snapshot := memsnap.New(*ser)
@@ -60,7 +70,7 @@ func TestSaveAndGetAggregateSnapshotAndEvents(t *testing.T) {
 	person.GrowOlder()
 	repo.Save(person)
 	twin := Person{}
-	err = repo.Get(string(person.ID()), &twin)
+	err = repo.Get(person.ID(), &twin)
 	if err != nil {
 		t.Fatal("could not get aggregate")
 	}


### PR DESCRIPTION
Change that an eventstore return an ErrNoEvents when there is no events when trying to get events for an aggregate. 