### PR TITLE
Global event get

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Save(aggregate Aggregate) (Version, error)
 
 // retrieves and build an aggregate from events based on its identifier
 Get(id string, aggregate Aggregate) error
+
+// return count number of events in global order starting at the start position
+GlobalEvents(start, count uint64) ([]Event, error) {
 ```
 
 It is possible to save a snapshot of an aggregate reducing the amount of event needed to be fetched and applied.
@@ -179,6 +182,9 @@ Save(events []eventsourcing.Event) (Version, error)
 
 // fetches events based on identifier and type but also after a specific version. The version is used to load event that happened after a snapshot was taken.
 Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error)
+
+// return count number of events in global order starting at the start position
+GlobalEvents(start, count uint64) ([]Event, error) {
 ```
 
 Currently, there are three implementations.
@@ -296,6 +302,7 @@ type EventStore interface {
     // The returned Version is the last events global version stored to the event store
     Save(events []Event) (Version, error)
     Get(id string, aggregateType string, afterVersion Version) ([]Event, error)
+	GlobalEvents(start, count uint64) ([]Event, error) {
 }
 ```
 

--- a/eventstore/bbolt/go.mod
+++ b/eventstore/bbolt/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hallgren/eventsourcing v0.0.15-0.20210310221131-4bb8960a066e
 	go.etcd.io/bbolt v1.3.4
 )
+
+replace github.com/hallgren/eventsourcing => ../..

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -86,6 +86,26 @@ func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing
 	return events, nil
 }
 
+// GlobalEvents will return count events in order globaly from the start posistion
+func (e *Memory) GlobalEvents(start, count uint64) ([]eventsourcing.Event, error) {
+	var events []eventsourcing.Event
+	// make sure its thread safe
+	e.lock.Lock()
+	defer e.lock.Unlock()
+
+	for _, e := range e.eventsInOrder {
+		// find start position and append until counter is 0
+		if uint64(e.GlobalVersion) >= start {
+			events = append(events, e)
+			count--
+			if count == 0 {
+				break
+			}
+		}
+	}
+	return events, nil
+}
+
 // Close does nothing
 func (e *Memory) Close() {}
 

--- a/eventstore/sql/go.mod
+++ b/eventstore/sql/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/hallgren/eventsourcing v0.0.15-0.20210310221131-4bb8960a066e // indirect
 	github.com/proullon/ramsql v0.0.0-20181213202341-817cee58a244
 )
+
+replace github.com/hallgren/eventsourcing => ../..

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -90,57 +90,14 @@ func (s *SQL) Save(events []eventsourcing.Event) (eventsourcing.Version, error) 
 }
 
 // Get the events from database
-func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (events []eventsourcing.Event, err error) {
+func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error) {
 	selectStm := `Select seq, id, version, reason, type, timestamp, data, metadata from events where id=? and type=? and version>? order by version asc`
 	rows, err := s.db.Query(selectStm, id, aggregateType, afterVersion)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	for rows.Next() {
-		var globalVersion eventsourcing.Version
-		var eventMetaData map[string]interface{}
-		var version eventsourcing.Version
-		var id, reason, typ, timestamp string
-		var data, metadata string
-		if err := rows.Scan(&globalVersion, &id, &version, &reason, &typ, &timestamp, &data, &metadata); err != nil {
-			return nil, err
-		}
-
-		t, err := time.Parse(time.RFC3339, timestamp)
-		if err != nil {
-			return nil, err
-		}
-
-		f, ok := s.serializer.Type(typ, reason)
-		if !ok {
-			// if the typ/reason is not register jump over the event
-			continue
-		}
-
-		eventData := f()
-		err = s.serializer.Unmarshal([]byte(data), &eventData)
-		if err != nil {
-			return nil, err
-		}
-		if metadata != "" {
-			err = s.serializer.Unmarshal([]byte(metadata), &eventMetaData)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		events = append(events, eventsourcing.Event{
-			AggregateID:   id,
-			Version:       version,
-			GlobalVersion: globalVersion,
-			AggregateType: typ,
-			Reason:        reason,
-			Timestamp:     t,
-			Data:          eventData,
-			MetaData:      eventMetaData,
-		})
-	}
+	events, err := s.eventsFromRows(rows)
 	if len(events) == 0 {
 		return nil, eventsourcing.ErrNoEvents
 	}
@@ -149,13 +106,17 @@ func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Ve
 
 // GlobalEvents return count events in order globaly from the start posistion
 func (s *SQL) GlobalEvents(start, count uint64) ([]eventsourcing.Event, error) {
-	var events []eventsourcing.Event
 	selectStm := `Select seq, id, version, reason, type, timestamp, data, metadata from events where seq >= ? order by seq asc LIMIT ?`
 	rows, err := s.db.Query(selectStm, start, count)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	return s.eventsFromRows(rows)
+}
+
+func (s *SQL) eventsFromRows(rows *sql.Rows) ([]eventsourcing.Event, error) {
+	var events []eventsourcing.Event
 	for rows.Next() {
 		var globalVersion eventsourcing.Version
 		var eventMetaData map[string]interface{}

--- a/repository.go
+++ b/repository.go
@@ -9,6 +9,7 @@ import (
 type EventStore interface {
 	Save(events []Event) (Version, error)
 	Get(id string, aggregateType string, afterVersion Version) ([]Event, error)
+	GlobalEvents(start, count uint64) ([]Event, error)
 }
 
 // SnapshotStore interface expose the methods an snapshot store must uphold
@@ -100,4 +101,9 @@ func (r *Repository) Get(id string, aggregate Aggregate) error {
 	// apply the event on the aggregate
 	root.BuildFromHistory(aggregate, events)
 	return nil
+}
+
+// GlobalEvents will return count events in order globaly from the start posistion
+func (r *Repository) GlobalEvents(start, count uint64) ([]Event, error) {
+	return r.GlobalEvents(start, count)
 }

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -2,11 +2,11 @@ package eventsourcing_test
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/hallgren/eventsourcing"
 	"reflect"
 	"sync"
 	"testing"
+
+	"github.com/hallgren/eventsourcing"
 )
 
 func initSerializers(t *testing.T) []*eventsourcing.Serializer {
@@ -52,7 +52,6 @@ func TestSerializeDeserialize(t *testing.T) {
 			if err != nil {
 				t.Fatalf("could not Marshal data, %v", err)
 			}
-			fmt.Println(string(d))
 
 			f, ok := s.Type("SomeAggregate", "SomeData")
 			if !ok {


### PR DESCRIPTION
## Get x events by global position
Makes it possible to iterate the event stream and for example build read models asynchronously.