### PR TITLE
Snapshot none exported properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ type snapshotInternal struct {
 
 func (s *snapshot) Marshal(m eventsourcing.MarshalSnapshotFunc) ([]byte, error) {
 	snap := snapshotInternal{
-		UnExported: s.unexported,
+		Unexported: s.unexported,
 		Exported:   s.Exported,
 	}
 	return m(snap)

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Marshal(m eventsourcing.MarshalSnapshotFunc) ([]byte, error) {
 Unmarshal(m eventsourcing.UnmarshalSnapshotFunc, b []byte) error {
 ```
  
-Here is an exampel how the Marshal/Unmarshal methods is used in the snapshot aggregate. Marshal mapps its properties to a new internal struct with all its
+Here is an exampel how the Marshal/Unmarshal methods is used in the snapshot aggregate. Marshal maps its properties to a new internal struct with all its
 properties exported. The Unmarshal method unmarshal the internal struct and sets the aggregate properties.
 
 ```go

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Unmarshal(m eventsourcing.UnmarshalSnapshotFunc, b []byte) error {
 ```
  
 Here is an exampel how the Marshal/Unmarshal methods is used in the snapshot aggregate. Marshal mapps its properties to a new internal struct with all its
-propererties exported. The Unmarshal method unmarshal the internal struct and sets the aggregate properties.
+properties exported. The Unmarshal method unmarshal the internal struct and sets the aggregate properties.
 
 ```go
 type snapshot struct {

--- a/serializer.go
+++ b/serializer.go
@@ -6,18 +6,18 @@ import (
 )
 
 type eventFunc = func() interface{}
-type marshal func(v interface{}) ([]byte, error)
-type unmarshal func(data []byte, v interface{}) error
+type MarshalSnapshot func(v interface{}) ([]byte, error)
+type UnmarshalSnapshot func(data []byte, v interface{}) error
 
 // Serializer for json serializes
 type Serializer struct {
 	eventRegister map[string]eventFunc
-	marshal       marshal
-	unmarshal     unmarshal
+	marshal       MarshalSnapshot
+	unmarshal     UnmarshalSnapshot
 }
 
 // NewSerializer returns a json Handle
-func NewSerializer(marshalF marshal, unmarshalF unmarshal) *Serializer {
+func NewSerializer(marshalF MarshalSnapshot, unmarshalF UnmarshalSnapshot) *Serializer {
 	return &Serializer{
 		eventRegister: make(map[string]eventFunc),
 		marshal:       marshalF,

--- a/serializer.go
+++ b/serializer.go
@@ -6,18 +6,18 @@ import (
 )
 
 type eventFunc = func() interface{}
-type MarshalSnapshot func(v interface{}) ([]byte, error)
-type UnmarshalSnapshot func(data []byte, v interface{}) error
+type MarshalSnapshotFunc func(v interface{}) ([]byte, error)
+type UnmarshalSnapshotFunc func(data []byte, v interface{}) error
 
 // Serializer for json serializes
 type Serializer struct {
 	eventRegister map[string]eventFunc
-	marshal       MarshalSnapshot
-	unmarshal     UnmarshalSnapshot
+	marshal       MarshalSnapshotFunc
+	unmarshal     UnmarshalSnapshotFunc
 }
 
 // NewSerializer returns a json Handle
-func NewSerializer(marshalF MarshalSnapshot, unmarshalF UnmarshalSnapshot) *Serializer {
+func NewSerializer(marshalF MarshalSnapshotFunc, unmarshalF UnmarshalSnapshotFunc) *Serializer {
 	return &Serializer{
 		eventRegister: make(map[string]eventFunc),
 		marshal:       marshalF,

--- a/snapshot.go
+++ b/snapshot.go
@@ -23,8 +23,8 @@ type Snapshot struct {
 // SnapshotAggregate is an Aggregate plus extra methods to help serialize into a snapshot
 type SnapshotAggregate interface {
 	Aggregate
-	Marshal(m MarshalSnapshot) ([]byte, error)
-	UnMarshal(m UnmarshalSnapshot, b []byte) error
+	Marshal(m MarshalSnapshotFunc) ([]byte, error)
+	Unmarshal(m UnmarshalSnapshotFunc, b []byte) error
 }
 
 // SnapshotHandler gets and saves snapshots
@@ -105,7 +105,7 @@ func (s *SnapshotHandler) Get(id string, i interface{}) error {
 	}
 	switch a := i.(type) {
 	case SnapshotAggregate:
-		err := a.UnMarshal(s.serializer.Unmarshal, snap.State)
+		err := a.Unmarshal(s.serializer.Unmarshal, snap.State)
 		if err != nil {
 			return err
 		}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -18,6 +18,7 @@ type snapshot struct {
 }
 
 type Event struct{}
+type Event2 struct {}
 
 func New() *snapshot {
 	s := snapshot{}
@@ -25,11 +26,18 @@ func New() *snapshot {
 	return &s
 }
 
+func (s *snapshot) Command() {
+	s.TrackChange(s ,&Event2{})
+}
+
 func (s *snapshot) Transition(e eventsourcing.Event) {
 	switch e.Data.(type) {
 	case *Event:
 		s.unexported = "unexported"
 		s.Exported = "Exported"
+	case *Event2:
+		s.unexported = "unexported2"
+		s.Exported = "Exported2"
 	}
 }
 
@@ -70,6 +78,10 @@ func TestSnapshotNoneExported(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	snap.Command()
+	repo.Save(snap)
+
 	snap2 := snapshot{}
 	err = repo.Get(snap.ID(), &snap2)
 


### PR DESCRIPTION
A way to handle none exported properties on a aggregate when taking a snapshot.