### PR TITLE
Serializer Events() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,10 +295,10 @@ The registered event function is used internally inside the event store to set t
 event data into the `eventsourcing.Event`.
 
 ```go
-RegisterTypes(aggregate Aggregate, events ...func() interface{})
+RegisterTypes(aggregate Aggregate, events []func() interface{})
 
-Register the aggregate Person and the event Born (Makes use of the helper method `Event` from the serializer.):
-serializer.RegisterTypes(&Person{}, serializer.Event(&Born{}))
+Register the aggregate Person and the events Born and AgedOneYear (Makes use of the helper method `Events` from the serializer instance):
+serializer.RegisterTypes(&Person{}, serializer.Events(&Born{}, &AgedOneYear{}))
 ```
 
 ### Event Subscription

--- a/README.md
+++ b/README.md
@@ -293,11 +293,12 @@ serializer := NewSerializer(json.Marshal, json.Unmarshal)
 
 The registered event function is used internally inside the event store to set the correct type info when unmarshalling
 event data into the `eventsourcing.Event`.
+
 ```go
 RegisterTypes(aggregate Aggregate, events ...func() interface{})
 
-register the aggregate Person and the event Born:
-serializer.RegisterTypes(&Person{}, func() interface{} { return &Born{}})
+Register the aggregate Person and the event Born (Makes use of the helper method `Event` from the serializer.):
+serializer.RegisterTypes(&Person{}, serializer.Event(&Born{}))
 ```
 
 ### Event Subscription

--- a/serializer.go
+++ b/serializer.go
@@ -49,8 +49,9 @@ func (h *Serializer) Events(events ...interface{}) []eventFunc {
 	return res
 }
 
-// RegisterTypes events aggregate
-func (h *Serializer) RegisterTypes(aggregate Aggregate, events []eventFunc) error {
+// Register will hold a map of aggregate_event to be able to set the currect type when
+// the data is unmarhaled.
+func (h *Serializer) Register(aggregate Aggregate, events []eventFunc) error {
 	typ := reflect.TypeOf(aggregate).Elem().Name()
 	if typ == "" {
 		return ErrAggregateNameMissing
@@ -68,6 +69,11 @@ func (h *Serializer) RegisterTypes(aggregate Aggregate, events []eventFunc) erro
 		h.eventRegister[typ+"_"+reason] = f
 	}
 	return nil
+}
+
+// RegisterTypes events aggregate
+func (h *Serializer) RegisterTypes(aggregate Aggregate, events ...eventFunc) error {
+	return h.Register(aggregate, events)
 }
 
 // Type return a struct from the registry

--- a/serializer.go
+++ b/serializer.go
@@ -36,6 +36,11 @@ var (
 	ErrEventNameMissing = errors.New("missing event name")
 )
 
+// Event is a helper function to make the event type registration simpler to use
+func (h *Serializer) Event(d interface{}) eventFunc {
+	return func() interface{} { return d }
+}
+
 // RegisterTypes events aggregate
 func (h *Serializer) RegisterTypes(aggregate Aggregate, events ...eventFunc) error {
 	typ := reflect.TypeOf(aggregate).Elem().Name()

--- a/serializer.go
+++ b/serializer.go
@@ -36,13 +36,21 @@ var (
 	ErrEventNameMissing = errors.New("missing event name")
 )
 
-// Event is a helper function to make the event type registration simpler to use
-func (h *Serializer) Event(d interface{}) eventFunc {
-	return func() interface{} { return d }
+func event(event interface{}) eventFunc {
+	return func() interface{} { return event }
+}
+
+// Events is a helper function to make the event type registration simpler
+func (h *Serializer) Events(events ...interface{}) []eventFunc {
+	res := []eventFunc{}
+	for _, e := range events {
+		res = append(res, event(e))
+	}
+	return res
 }
 
 // RegisterTypes events aggregate
-func (h *Serializer) RegisterTypes(aggregate Aggregate, events ...eventFunc) error {
+func (h *Serializer) RegisterTypes(aggregate Aggregate, events []eventFunc) error {
 	typ := reflect.TypeOf(aggregate).Elem().Name()
 	if typ == "" {
 		return ErrAggregateNameMissing

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -12,7 +12,7 @@ import (
 func initSerializers(t *testing.T) []*eventsourcing.Serializer {
 	var result []*eventsourcing.Serializer
 	s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
-	err := s.RegisterTypes(&SomeAggregate{}, func() interface{} { return &SomeData{} }, func() interface{} { return &SomeData2{} })
+	err := s.RegisterTypes(&SomeAggregate{}, s.Event(&SomeData{}), s.Event(&SomeData2{}))
 	if err != nil {
 		t.Fatalf("could not register aggregate events %v", err)
 	}

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -12,7 +12,7 @@ import (
 func initSerializers(t *testing.T) []*eventsourcing.Serializer {
 	var result []*eventsourcing.Serializer
 	s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
-	err := s.RegisterTypes(&SomeAggregate{}, s.Events(&SomeData{}, &SomeData2{}))
+	err := s.Register(&SomeAggregate{}, s.Events(&SomeData{}, &SomeData2{}))
 	if err != nil {
 		t.Fatalf("could not register aggregate events %v", err)
 	}

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -12,7 +12,7 @@ import (
 func initSerializers(t *testing.T) []*eventsourcing.Serializer {
 	var result []*eventsourcing.Serializer
 	s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
-	err := s.RegisterTypes(&SomeAggregate{}, s.Event(&SomeData{}), s.Event(&SomeData2{}))
+	err := s.RegisterTypes(&SomeAggregate{}, s.Events(&SomeData{}, &SomeData2{}))
 	if err != nil {
 		t.Fatalf("could not register aggregate events %v", err)
 	}


### PR DESCRIPTION
Makes the event registration simpler.

### From:
s.RegisterTypes(&SomeAggregate{}, func() interface{} { return &SomeData{} }, func() interface{} { return &SomeData2{} })

### To:
s.Register(&SomeAggregate{}, s.**Events**(&SomeData{}, &SomeData2{}))

The "old" method RegisterTypes will still be present to keep backwards compatibility.
       