### PR TITLE
Event iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ Save(aggregate Aggregate) error
 
 // retrieves and build an aggregate from events based on its identifier
 Get(id string, aggregate Aggregate) error
-
-// return count number of events in global order starting at the start position
-GlobalEvents(start, count uint64) ([]Event, error) {
 ```
 
 It is possible to save a snapshot of an aggregate reducing the amount of event needed to be fetched and applied.
@@ -179,10 +176,7 @@ The only thing an event store handles are events, and it must implement the foll
 Save(events []eventsourcing.Event) error
 
 // fetches events based on identifier and type but also after a specific version. The version is used to load event that happened after a snapshot was taken.
-Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error)
-
-// return count number of events in global order starting at the start position
-GlobalEvents(start, count uint64) ([]Event, error) {
+Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error)
 ```
 
 Currently, there are three implementations.
@@ -356,8 +350,7 @@ A custom-made event store has to implement the following functions to fulfill th
 ```go
 type EventStore interface {
     Save(events []Event) error
-    Get(id string, aggregateType string, afterVersion Version) ([]Event, error)
-    GlobalEvents(start, count uint64) ([]Event, error) {
+    Get(id string, aggregateType string, afterVersion Version) (EventIterator, error)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ The repository is used to save and retrieve aggregates. The main functions are:
 Save(aggregate Aggregate) error
 
 // retrieves and build an aggregate from events based on its identifier
+// possible to cancel from the outside
+GetWithContext(ctx context.Context, id string, aggregate Aggregate) error
+
+// retrieves and build an aggregate from events based on its identifier
 Get(id string, aggregate Aggregate) error
 ```
 

--- a/README.md
+++ b/README.md
@@ -254,14 +254,14 @@ The Snapshot Handler is the top layer that integrates with the repository.
 Save(a interface{}) error {
 
 // Get fetch a snapshot and reconstruct an aggregate
-Get(id string, a interface{}) error {
+Get(ctx context.Context, id string, a interface{}) error {
 ```
 
 A Snapshot store is the actual layer that stores the snapshot.
 
 ```go
 // get snapshot by identifier
-Get(id, typ string) (eventsource.Snapshot, error)
+Get(ctx context.Context, id, typ string) (eventsource.Snapshot, error)
 
 // saves snapshot
 Save(s eventsourcing.Snapshot) error
@@ -364,7 +364,7 @@ If the snapshot store is the thing you need to change here is the interface you 
 
 ```go
 type SnapshotStore interface {
-    Get(id string, a interface{}) error
+    Get(ctx context.Context, id string, a interface{}) error
     Save(id string, a interface{}) error
 }
 ```

--- a/event.go
+++ b/event.go
@@ -30,8 +30,3 @@ func (e Event) Reason() string {
 	}
 	return reflect.TypeOf(e.Data).Elem().Name()
 }
-
-type EventIterator interface {
-	Next() (Event, error)
-	Close()
-}

--- a/event.go
+++ b/event.go
@@ -9,6 +9,9 @@ import (
 // ErrNoEvents when there is no events to get
 var ErrNoEvents = errors.New("no events")
 
+// ErrNoMoreEvents when iterator has no more events to deliver
+var ErrNoMoreEvents = errors.New("no more events")
+
 // Event holding meta data and the application specific event in the Data property
 type Event struct {
 	AggregateID   string
@@ -28,11 +31,7 @@ func (e Event) Reason() string {
 	return reflect.TypeOf(e.Data).Elem().Name()
 }
 
-type Iterator interface {
+type EventIterator interface {
 	Next() (Event, error)
 	Close()
-}
-
-type EventIterator struct {
-	Iterator
 }

--- a/event.go
+++ b/event.go
@@ -27,3 +27,12 @@ func (e Event) Reason() string {
 	}
 	return reflect.TypeOf(e.Data).Elem().Name()
 }
+
+type Iterator interface {
+	Next() (Event, error)
+	Close()
+}
+
+type EventIterator struct {
+	Iterator
+}

--- a/eventstore/bbolt/bbolt.go
+++ b/eventstore/bbolt/bbolt.go
@@ -231,9 +231,7 @@ func (e *BBolt) Get(id string, aggregateType string, afterVersion eventsourcing.
 	if err != nil {
 		return nil, err
 	}
-
 	firstEvent := afterVersion + 1
-
 	i := iterator{tx: tx, bucketName: bucketName, firstEventIndex: uint64(firstEvent), serializer: e.serializer}
 	return &i, nil
 

--- a/eventstore/bbolt/bbolt.go
+++ b/eventstore/bbolt/bbolt.go
@@ -1,6 +1,7 @@
 package bbolt
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -167,7 +168,7 @@ func (e *BBolt) Save(events []eventsourcing.Event) error {
 }
 
 // Get aggregate events
-func (e *BBolt) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
+func (e *BBolt) Get(ctx context.Context, id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	bucketName := aggregateKey(aggregateType, id)
 
 	tx, err := e.db.Begin(false)

--- a/eventstore/bbolt/iterator.go
+++ b/eventstore/bbolt/iterator.go
@@ -1,0 +1,68 @@
+package bbolt
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hallgren/eventsourcing"
+	"go.etcd.io/bbolt"
+)
+
+type iterator struct {
+	tx              *bbolt.Tx
+	bucketName      string
+	firstEventIndex uint64
+	cursor          *bbolt.Cursor
+	serializer      eventsourcing.Serializer
+}
+
+// Close closes the iterator
+func (i *iterator) Close() {
+	i.tx.Rollback()
+}
+
+// Next return the next event
+func (i *iterator) Next() (eventsourcing.Event, error) {
+	var k, obj []byte
+	if i.cursor == nil {
+		bucket := i.tx.Bucket([]byte(i.bucketName))
+		if bucket == nil {
+			return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+		}
+		i.cursor = bucket.Cursor()
+		k, obj = i.cursor.Seek(itob(i.firstEventIndex))
+		if k == nil {
+			return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+		}
+	} else {
+		k, obj = i.cursor.Next()
+	}
+	if k == nil {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+	}
+	bEvent := boltEvent{}
+	err := i.serializer.Unmarshal(obj, &bEvent)
+	if err != nil {
+		return eventsourcing.Event{}, errors.New(fmt.Sprintf("could not deserialize event, %v", err))
+	}
+	f, ok := i.serializer.Type(bEvent.AggregateType, bEvent.Reason)
+	if !ok {
+		// if the typ/reason is not register jump over the event
+		return i.Next()
+	}
+	eventData := f()
+	err = i.serializer.Unmarshal(bEvent.Data, &eventData)
+	if err != nil {
+		return eventsourcing.Event{}, errors.New(fmt.Sprintf("could not deserialize event data, %v", err))
+	}
+	event := eventsourcing.Event{
+		AggregateID:   bEvent.AggregateID,
+		AggregateType: bEvent.AggregateType,
+		Version:       eventsourcing.Version(bEvent.Version),
+		GlobalVersion: eventsourcing.Version(bEvent.GlobalVersion),
+		Timestamp:     bEvent.Timestamp,
+		Metadata:      bEvent.Metadata,
+		Data:          eventData,
+	}
+	return event, nil
+}

--- a/eventstore/esdb/esdb.go
+++ b/eventstore/esdb/esdb.go
@@ -94,8 +94,7 @@ func (es *ESDB) Save(events []eventsourcing.Event) error {
 	return nil
 }
 
-func (es *ESDB) Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error) {
-	var events []eventsourcing.Event
+func (es *ESDB) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	streamID := stream(aggregateType, id)
 
 	from := esdb.StreamRevision{Value: uint64(afterVersion)}
@@ -106,47 +105,56 @@ func (es *ESDB) Get(id string, aggregateType string, afterVersion eventsourcing.
 		}
 		return nil, err
 	}
-	defer stream.Close()
+	return &iterator{stream: stream, serializer: es.serializer}, nil
+}
 
-	for {
-		var eventMetadata map[string]interface{}
-		event, err := stream.Recv()
-		if errors.Is(err, io.EOF) {
-			break
-		}
-		if err != nil {
-			return nil, err
-		}
+type iterator struct {
+	stream     *esdb.ReadStream
+	serializer eventsourcing.Serializer
+}
 
-		stream := strings.Split(event.Event.StreamID, streamSeparator)
-		f, ok := es.serializer.Type(stream[0], event.Event.EventType)
-		if !ok {
-			// if the typ/reason is not register jump over the event
-			continue
-		}
-		eventData := f()
-		err = es.serializer.Unmarshal(event.Event.Data, &eventData)
-		if err != nil {
-			return nil, err
-		}
-		if event.Event.UserMetadata != nil {
-			err = es.serializer.Unmarshal(event.Event.UserMetadata, &eventMetadata)
-			if err != nil {
-				return nil, err
-			}
-		}
-		events = append(events, eventsourcing.Event{
-			AggregateID:   stream[1],
-			Version:       eventsourcing.Version(event.Event.EventNumber) + 1, // +1 as the eventsourcing Version starts on 1 but the esdb event version starts on 0
-			AggregateType: stream[0],
-			Timestamp:     event.Event.CreatedDate,
-			Data:          eventData,
-			Metadata:      eventMetadata,
-			// Can't get the global version when using the ReadStream method
-			//GlobalVersion: eventsourcing.Version(event.Event.Position.Commit),
-		})
+func (i *iterator) Close() {
+	i.stream.Close()
+}
+
+func (i *iterator) Next() (eventsourcing.Event, error) {
+	var eventMetadata map[string]interface{}
+	eventESDB, err := i.stream.Recv()
+	if errors.Is(err, io.EOF) {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
 	}
-	return events, nil
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	stream := strings.Split(eventESDB.Event.StreamID, streamSeparator)
+	f, ok := i.serializer.Type(stream[0], eventESDB.Event.EventType)
+	if !ok {
+		// if the typ/reason is not register jump over the event
+		return i.Next()
+	}
+	eventData := f()
+	err = i.serializer.Unmarshal(eventESDB.Event.Data, &eventData)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+	if eventESDB.Event.UserMetadata != nil {
+		err = i.serializer.Unmarshal(eventESDB.Event.UserMetadata, &eventMetadata)
+		if err != nil {
+			return eventsourcing.Event{}, err
+		}
+	}
+	event := eventsourcing.Event{
+		AggregateID:   stream[1],
+		Version:       eventsourcing.Version(eventESDB.Event.EventNumber) + 1, // +1 as the eventsourcing Version starts on 1 but the esdb event version starts on 0
+		AggregateType: stream[0],
+		Timestamp:     eventESDB.Event.CreatedDate,
+		Data:          eventData,
+		Metadata:      eventMetadata,
+		// Can't get the global version when using the ReadStream method
+		//GlobalVersion: eventsourcing.Version(event.Event.Position.Commit),
+	}
+	return event, nil
 }
 
 func stream(aggregateType, aggregateID string) string {

--- a/eventstore/esdb/iterator.go
+++ b/eventstore/esdb/iterator.go
@@ -1,0 +1,61 @@
+package esdb
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/EventStore/EventStore-Client-Go/esdb"
+	"github.com/hallgren/eventsourcing"
+)
+
+type iterator struct {
+	stream     *esdb.ReadStream
+	serializer eventsourcing.Serializer
+}
+
+// Close closes the stream
+func (i *iterator) Close() {
+	i.stream.Close()
+}
+
+// Next returns next event from the stream
+func (i *iterator) Next() (eventsourcing.Event, error) {
+	var eventMetadata map[string]interface{}
+	eventESDB, err := i.stream.Recv()
+	if errors.Is(err, io.EOF) {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+	}
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	stream := strings.Split(eventESDB.Event.StreamID, streamSeparator)
+	f, ok := i.serializer.Type(stream[0], eventESDB.Event.EventType)
+	if !ok {
+		// if the typ/reason is not register jump over the event
+		return i.Next()
+	}
+	eventData := f()
+	err = i.serializer.Unmarshal(eventESDB.Event.Data, &eventData)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+	if eventESDB.Event.UserMetadata != nil {
+		err = i.serializer.Unmarshal(eventESDB.Event.UserMetadata, &eventMetadata)
+		if err != nil {
+			return eventsourcing.Event{}, err
+		}
+	}
+	event := eventsourcing.Event{
+		AggregateID:   stream[1],
+		Version:       eventsourcing.Version(eventESDB.Event.EventNumber) + 1, // +1 as the eventsourcing Version starts on 1 but the esdb event version starts on 0
+		AggregateType: stream[0],
+		Timestamp:     eventESDB.Event.CreatedDate,
+		Data:          eventData,
+		Metadata:      eventMetadata,
+		// Can't get the global version when using the ReadStream method
+		//GlobalVersion: eventsourcing.Version(event.Event.Position.Commit),
+	}
+	return event, nil
+}

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"sync"
 
 	"github.com/hallgren/eventsourcing"
@@ -86,7 +87,7 @@ func (e *Memory) Save(events []eventsourcing.Event) error {
 }
 
 // Get aggregate events
-func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
+func (e *Memory) Get(ctx context.Context, id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	var events []eventsourcing.Event
 	// make sure its thread safe
 	e.lock.Lock()

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -1,7 +1,6 @@
 package memory
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/hallgren/eventsourcing"
@@ -21,8 +20,8 @@ type iterator struct {
 }
 
 func (i *iterator) Next() (eventsourcing.Event, error) {
-	if len(i.events) <= i.position+1 {
-		return eventsourcing.Event{}, fmt.Errorf("no more events")
+	if len(i.events) <= i.position {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
 	}
 	event := i.events[i.position]
 	i.position++
@@ -87,7 +86,7 @@ func (e *Memory) Save(events []eventsourcing.Event) error {
 }
 
 // Get aggregate events
-func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (*eventsourcing.EventIterator, error) {
+func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	var events []eventsourcing.Event
 	// make sure its thread safe
 	e.lock.Lock()
@@ -101,7 +100,7 @@ func (e *Memory) Get(id string, aggregateType string, afterVersion eventsourcing
 	if len(events) == 0 {
 		return nil, eventsourcing.ErrNoEvents
 	}
-	return iterator{events: events}, nil
+	return &iterator{events: events}, nil
 }
 
 // GlobalEvents will return count events in order globaly from the start posistion

--- a/eventstore/sql/iterator.go
+++ b/eventstore/sql/iterator.go
@@ -1,0 +1,67 @@
+package sql
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/hallgren/eventsourcing"
+)
+
+type iterator struct {
+	rows       *sql.Rows
+	serializer eventsourcing.Serializer
+}
+
+// Next return the next event
+func (i *iterator) Next() (eventsourcing.Event, error) {
+	var globalVersion eventsourcing.Version
+	var eventMetadata map[string]interface{}
+	var version eventsourcing.Version
+	var id, reason, typ, timestamp string
+	var data, metadata string
+	if !i.rows.Next() {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+	}
+	if err := i.rows.Scan(&globalVersion, &id, &version, &reason, &typ, &timestamp, &data, &metadata); err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	f, ok := i.serializer.Type(typ, reason)
+	if !ok {
+		// if the typ/reason is not register jump over the event
+		return i.Next()
+	}
+
+	eventData := f()
+	err = i.serializer.Unmarshal([]byte(data), &eventData)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+	if metadata != "" {
+		err = i.serializer.Unmarshal([]byte(metadata), &eventMetadata)
+		if err != nil {
+			return eventsourcing.Event{}, err
+		}
+	}
+
+	event := eventsourcing.Event{
+		AggregateID:   id,
+		Version:       version,
+		GlobalVersion: globalVersion,
+		AggregateType: typ,
+		Timestamp:     t,
+		Data:          eventData,
+		Metadata:      eventMetadata,
+	}
+	return event, nil
+}
+
+// Close closes the iterator
+func (i *iterator) Close() {
+	i.rows.Close()
+}

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -95,11 +95,13 @@ func (s *SQL) Save(events []eventsourcing.Event) error {
 }
 
 // Get the events from database
-func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
+func (s *SQL) Get(ctx context.Context, id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	selectStm := `Select seq, id, version, reason, type, timestamp, data, metadata from events where id=? and type=? and version>? order by version asc`
-	rows, err := s.db.Query(selectStm, id, aggregateType, afterVersion)
+	rows, err := s.db.QueryContext(ctx, selectStm, id, aggregateType, afterVersion)
 	if err != nil {
 		return nil, err
+	} else if ctx.Err() != nil {
+		return nil, ctx.Err()
 	}
 	i := iterator{rows: rows, serializer: s.serializer}
 	return &i, nil

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -94,19 +94,72 @@ func (s *SQL) Save(events []eventsourcing.Event) error {
 	return tx.Commit()
 }
 
+type iterator struct {
+	rows       *sql.Rows
+	serializer eventsourcing.Serializer
+}
+
+func (i *iterator) Close() {
+	i.rows.Close()
+}
+
+func (i *iterator) Next() (eventsourcing.Event, error) {
+	var globalVersion eventsourcing.Version
+	var eventMetadata map[string]interface{}
+	var version eventsourcing.Version
+	var id, reason, typ, timestamp string
+	var data, metadata string
+	if !i.rows.Next() {
+		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
+	}
+	if err := i.rows.Scan(&globalVersion, &id, &version, &reason, &typ, &timestamp, &data, &metadata); err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	t, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+
+	f, ok := i.serializer.Type(typ, reason)
+	if !ok {
+		// if the typ/reason is not register jump over the event
+		return i.Next()
+	}
+
+	eventData := f()
+	err = i.serializer.Unmarshal([]byte(data), &eventData)
+	if err != nil {
+		return eventsourcing.Event{}, err
+	}
+	if metadata != "" {
+		err = i.serializer.Unmarshal([]byte(metadata), &eventMetadata)
+		if err != nil {
+			return eventsourcing.Event{}, err
+		}
+	}
+
+	event := eventsourcing.Event{
+		AggregateID:   id,
+		Version:       version,
+		GlobalVersion: globalVersion,
+		AggregateType: typ,
+		Timestamp:     t,
+		Data:          eventData,
+		Metadata:      eventMetadata,
+	}
+	return event, nil
+}
+
 // Get the events from database
-func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) ([]eventsourcing.Event, error) {
+func (s *SQL) Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.EventIterator, error) {
 	selectStm := `Select seq, id, version, reason, type, timestamp, data, metadata from events where id=? and type=? and version>? order by version asc`
 	rows, err := s.db.Query(selectStm, id, aggregateType, afterVersion)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
-	events, err := s.eventsFromRows(rows)
-	if len(events) == 0 {
-		return nil, eventsourcing.ErrNoEvents
-	}
-	return events, nil
+	i := iterator{rows: rows, serializer: s.serializer}
+	return &i, nil
 }
 
 // GlobalEvents return count events in order globaly from the start posistion

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hallgren/eventsourcing/eventstore"
 )
 
-// SQL for store events
+// SQL event store handler
 type SQL struct {
 	db         *sql.DB
 	serializer eventsourcing.Serializer
@@ -92,63 +92,6 @@ func (s *SQL) Save(events []eventsourcing.Event) error {
 		events[i].GlobalVersion = eventsourcing.Version(lastInsertedID)
 	}
 	return tx.Commit()
-}
-
-type iterator struct {
-	rows       *sql.Rows
-	serializer eventsourcing.Serializer
-}
-
-func (i *iterator) Close() {
-	i.rows.Close()
-}
-
-func (i *iterator) Next() (eventsourcing.Event, error) {
-	var globalVersion eventsourcing.Version
-	var eventMetadata map[string]interface{}
-	var version eventsourcing.Version
-	var id, reason, typ, timestamp string
-	var data, metadata string
-	if !i.rows.Next() {
-		return eventsourcing.Event{}, eventsourcing.ErrNoMoreEvents
-	}
-	if err := i.rows.Scan(&globalVersion, &id, &version, &reason, &typ, &timestamp, &data, &metadata); err != nil {
-		return eventsourcing.Event{}, err
-	}
-
-	t, err := time.Parse(time.RFC3339, timestamp)
-	if err != nil {
-		return eventsourcing.Event{}, err
-	}
-
-	f, ok := i.serializer.Type(typ, reason)
-	if !ok {
-		// if the typ/reason is not register jump over the event
-		return i.Next()
-	}
-
-	eventData := f()
-	err = i.serializer.Unmarshal([]byte(data), &eventData)
-	if err != nil {
-		return eventsourcing.Event{}, err
-	}
-	if metadata != "" {
-		err = i.serializer.Unmarshal([]byte(metadata), &eventMetadata)
-		if err != nil {
-			return eventsourcing.Event{}, err
-		}
-	}
-
-	event := eventsourcing.Event{
-		AggregateID:   id,
-		Version:       version,
-		GlobalVersion: globalVersion,
-		AggregateType: typ,
-		Timestamp:     t,
-		Data:          eventData,
-		Metadata:      eventMetadata,
-	}
-	return event, nil
 }
 
 // Get the events from database

--- a/eventstore/suite/suite.go
+++ b/eventstore/suite/suite.go
@@ -354,7 +354,10 @@ func getErrWhenNoEvents(es eventsourcing.EventStore) error {
 	aggregateID := AggregateID()
 	iterator, err := es.Get(aggregateID, aggregateType, 0)
 	if err != nil {
-		return err
+		if err != eventsourcing.ErrNoEvents {
+			return err
+		}
+		return nil
 	}
 	defer iterator.Close()
 	_, err = iterator.Next()

--- a/eventstore/suite/suite.go
+++ b/eventstore/suite/suite.go
@@ -1,6 +1,7 @@
 package suite
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -134,7 +135,7 @@ func saveAndGetEvents(es eventsourcing.EventStore) error {
 	if err != nil {
 		return err
 	}
-	iterator, err := es.Get(aggregateID, aggregateType, 0)
+	iterator, err := es.Get(context.Background(), aggregateID, aggregateType, 0)
 	if err != nil {
 		return err
 	}
@@ -163,7 +164,7 @@ func saveAndGetEvents(es eventsourcing.EventStore) error {
 		return err
 	}
 	fetchedEventsIncludingPartTwo := []eventsourcing.Event{}
-	iterator, err = es.Get(aggregateID, aggregateType, 0)
+	iterator, err = es.Get(context.Background(), aggregateID, aggregateType, 0)
 	if err != nil {
 		return err
 	}
@@ -219,7 +220,7 @@ func getEventsAfterVersion(es eventsourcing.EventStore) error {
 		return err
 	}
 
-	iterator, err := es.Get(aggregateID, aggregateType, 1)
+	iterator, err := es.Get(context.Background(), aggregateID, aggregateType, 1)
 	if err != nil {
 		return err
 	}
@@ -323,7 +324,7 @@ func saveAndGetEventsConcurrently(es eventsourcing.EventStore) error {
 		eventID := fmt.Sprintf("%s-%d", aggregateID, i)
 		go func() {
 			defer wg.Done()
-			iterator, e := es.Get(eventID, aggregateType, 0)
+			iterator, e := es.Get(context.Background(), eventID, aggregateType, 0)
 			if e != nil {
 				err = e
 				return
@@ -352,7 +353,7 @@ func saveAndGetEventsConcurrently(es eventsourcing.EventStore) error {
 
 func getErrWhenNoEvents(es eventsourcing.EventStore) error {
 	aggregateID := AggregateID()
-	iterator, err := es.Get(aggregateID, aggregateType, 0)
+	iterator, err := es.Get(context.Background(), aggregateID, aggregateType, 0)
 	if err != nil {
 		if err != eventsourcing.ErrNoEvents {
 			return err

--- a/eventstore/suite/suite.go
+++ b/eventstore/suite/suite.go
@@ -140,8 +140,11 @@ func saveAndGetEvents(es eventsourcing.EventStore) error {
 	}
 	for {
 		event, err := iterator.Next()
-		if err != nil {
+		if errors.Is(err, eventsourcing.ErrNoMoreEvents) {
 			break
+		}
+		if err != nil {
+			return err
 		}
 		fetchedEvents = append(fetchedEvents, event)
 	}

--- a/eventstore/suite/suite.go
+++ b/eventstore/suite/suite.go
@@ -352,8 +352,13 @@ func saveAndGetEventsConcurrently(es eventsourcing.EventStore) error {
 
 func getErrWhenNoEvents(es eventsourcing.EventStore) error {
 	aggregateID := AggregateID()
-	_, err := es.Get(aggregateID, aggregateType, 0)
-	if !errors.Is(err, eventsourcing.ErrNoEvents) {
+	iterator, err := es.Get(aggregateID, aggregateType, 0)
+	if err != nil {
+		return err
+	}
+	defer iterator.Close()
+	_, err = iterator.Next()
+	if !errors.Is(err, eventsourcing.ErrNoMoreEvents) {
 		return fmt.Errorf("expect error when no events are saved for aggregate")
 	}
 	return nil

--- a/repository.go
+++ b/repository.go
@@ -89,6 +89,8 @@ func (r *Repository) GetWithContext(ctx context.Context, id string, aggregate Ag
 		err := r.snapshot.Get(ctx, id, aggregate)
 		if err != nil && !errors.Is(err, ErrSnapshotNotFound) {
 			return err
+		} else if ctx.Err() != nil {
+			return ctx.Err()
 		}
 	}
 	root := aggregate.Root()

--- a/repository.go
+++ b/repository.go
@@ -79,7 +79,7 @@ func (r *Repository) SaveSnapshot(aggregate Aggregate) error {
 // GetWithContext fetches the aggregates event and build up the aggregate
 // If there is a snapshot store try fetch a snapshot of the aggregate and fetch event after the
 // version of the aggregate if any
-// The event fetching can be cancled from the outside.
+// The event fetching can be canceled from the outside.
 func (r *Repository) GetWithContext(ctx context.Context, id string, aggregate Aggregate) error {
 	if reflect.ValueOf(aggregate).Kind() != reflect.Ptr {
 		return errors.New("aggregate needs to be a pointer")

--- a/repository.go
+++ b/repository.go
@@ -20,8 +20,8 @@ type EventStore interface {
 
 // SnapshotStore interface expose the methods an snapshot store must uphold
 type SnapshotStore interface {
-	Get(id, typ string) (Snapshot, error)
 	Save(s Snapshot) error
+	Get(ctx context.Context, id, typ string) (Snapshot, error)
 }
 
 // Aggregate interface to use the aggregate root specific methods
@@ -86,7 +86,7 @@ func (r *Repository) GetWithContext(ctx context.Context, id string, aggregate Ag
 	}
 	// if there is a snapshot store try fetch aggregate snapshot
 	if r.snapshot != nil {
-		err := r.snapshot.Get(id, aggregate)
+		err := r.snapshot.Get(ctx, id, aggregate)
 		if err != nil && !errors.Is(err, ErrSnapshotNotFound) {
 			return err
 		}

--- a/repository.go
+++ b/repository.go
@@ -5,6 +5,12 @@ import (
 	"reflect"
 )
 
+// EventIterator is the interface an event store Get needs to return
+type EventIterator interface {
+	Next() (Event, error)
+	Close()
+}
+
 // EventStore interface expose the methods an event store must uphold
 type EventStore interface {
 	Save(events []Event) error

--- a/snapshot.go
+++ b/snapshot.go
@@ -1,6 +1,7 @@
 package eventsourcing
 
 import (
+	"context"
 	"errors"
 	"reflect"
 )
@@ -97,9 +98,9 @@ func (s *SnapshotHandler) saveAggregate(sa Aggregate) error {
 }
 
 // Get fetch a snapshot and reconstruct an aggregate
-func (s *SnapshotHandler) Get(id string, i interface{}) error {
+func (s *SnapshotHandler) Get(ctx context.Context, id string, i interface{}) error {
 	typ := reflect.TypeOf(i).Elem().Name()
-	snap, err := s.snapshotStore.Get(id, typ)
+	snap, err := s.snapshotStore.Get(ctx, id, typ)
 	if err != nil {
 		return err
 	}

--- a/snapshot_test.go
+++ b/snapshot_test.go
@@ -1,6 +1,7 @@
 package eventsourcing_test
 
 import (
+	"context"
 	"encoding/xml"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestSnapshot(t *testing.T) {
 	}
 
 	p := Person{}
-	err = s.Get("123", &p)
+	err = s.Get(context.Background(), "123", &p)
 	if err != nil {
 		t.Fatalf("could not get person from snapshot %v", err)
 	}
@@ -134,7 +135,7 @@ func TestSnapshot(t *testing.T) {
 	person.Age = 99
 	s.Save(person)
 
-	err = s.Get(person.ID(), &p)
+	err = s.Get(context.Background(), person.ID(), &p)
 	if err != nil {
 		t.Fatalf("could not get snapshot %v", err)
 	}
@@ -146,7 +147,7 @@ func TestGetNoneExistingSnapshot(t *testing.T) {
 	ser := eventsourcing.NewSerializer(xml.Marshal, xml.Unmarshal)
 	s := eventsourcing.SnapshotNew(memsnap.New(), *ser)
 	p := Person{}
-	err := s.Get("noneExistingID", &p)
+	err := s.Get(context.Background(), "noneExistingID", &p)
 	if err == nil {
 		t.Fatalf("could get none existing snapshot %v", err)
 	}

--- a/snapshotstore/memory/memory.go
+++ b/snapshotstore/memory/memory.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hallgren/eventsourcing"
@@ -19,7 +20,7 @@ func New() *Handler {
 }
 
 // Get returns the deserialize snapshot
-func (h *Handler) Get(id, typ string) (eventsourcing.Snapshot, error) {
+func (h *Handler) Get(ctx context.Context, id, typ string) (eventsourcing.Snapshot, error) {
 	v, ok := h.store[fmt.Sprintf("%s_%s", id, typ)]
 	if !ok {
 		return eventsourcing.Snapshot{}, eventsourcing.ErrSnapshotNotFound

--- a/snapshotstore/suite/suite.go
+++ b/snapshotstore/suite/suite.go
@@ -1,6 +1,7 @@
 package suite
 
 import (
+	"context"
 	"testing"
 
 	"github.com/hallgren/eventsourcing"
@@ -49,7 +50,7 @@ func TestSnapshot(t *testing.T, snapshot eventsourcing.SnapshotStore) {
 		t.Fatal(err)
 	}
 
-	snap2, err := snapshot.Get("123", "Person")
+	snap2, err := snapshot.Get(context.Background(), "123", "Person")
 	if err != nil {
 		t.Fatalf("could not get snapshot %v", err)
 	}


### PR DESCRIPTION
Make evenstore´s return an event iterator instead of a slice of events. To make the event fetching more stream based and reduce memory pressure. 