### PR TITLE
Eventstream retake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ example/example
 .idea
 coverage.txt
 *.swp
+go.work

--- a/README.md
+++ b/README.md
@@ -307,12 +307,12 @@ The repository expose four possibilities to subscribe to events in realtime as t
 
 `All(func (e Event)) *subscription` subscribes to all event.
 
-`Aggregate(func (e Event), events ...Aggregate) *subscription` events bound to specific aggregate based on type and identity.
+`AggregateID(func (e Event), events ...Aggregate) *subscription` events bound to specific aggregate based on type and identity.
 This makes it possible to get events pinpointed to one specific aggregate instance.
 
-`AggregateType(func (e Event), aggregates ...Aggregate) *subscription` subscribes to events bound to specific aggregate type. 
+`Aggregate(func (e Event), aggregates ...Aggregate) *subscription` subscribes to events bound to specific aggregate type. 
  
-`SpecificEvent(func (e Event), events ...interface{}) *subscription` subscribes to specific events. There are no restrictions that the events need
+`Event(func (e Event), events ...interface{}) *subscription` subscribes to specific events. There are no restrictions that the events need
 to come from the same aggregate, you can mix and match as you please.
 
 `Name(f func(e Event), aggregate string, events ...string) *subscription` subscribes to events based on aggregate type and event name.

--- a/README.md
+++ b/README.md
@@ -305,14 +305,18 @@ serializer.Register(&Person{}, serializer.Events(&Born{}, &AgedOneYear{}))
 
 The repository expose four possibilities to subscribe to events in realtime as they are saved to the repository.
 
-`SubscriberAll(func (e Event)) *Subscription` all event.
+`All(func (e Event)) *subscription` subscribes to all event.
 
-`SubscriberAggregateType(func (e Event), aggregates ...Aggregate) *Subscription` events bound to specific aggregate types. 
+`Aggregate(func (e Event), events ...Aggregate) *subscription` events bound to specific aggregate based on type and identity.
+This makes it possible to get events pinpointed to one specific aggregate instance.
+
+
+`AggregateType(func (e Event), aggregates ...Aggregate) *subscription` subscribes to events bound to specific aggregate type. 
  
-`SubscriberSpecificEvent(func (e Event), events ...interface{}) *Subscription` specific events. There are no restrictions that the events need
+`SpecificEvent(func (e Event), events ...interface{}) *subscription` subscribes to specific events. There are no restrictions that the events need
 to come from the same aggregate, you can mix and match as you please.
 
-`SubscriberSpecificAggregate(func (e Event), events ...Aggregate) *Subscription` events bound to specific aggregate based on type and identity. This makes it possible to get events pinpointed to one specific aggregate instance. 
+`Name(f func(e Event), aggregate string, events ...string) *subscription` subscribes to events based on aggregate type and event name.
 
 The subscription is realtime and events that are saved before the call to one of the subscribers will not be exposed via the `func(e Event)` function. If the application 
 depends on this functionality make sure to call Subscribe() function on the subscriber before storing events in the repository. 
@@ -327,7 +331,7 @@ Example on how to set up the event subscription and consume the event `FrequentF
 repo := eventsourcing.NewRepository(memory.Create(), nil)
 
 // subscriber that will trigger on every saved events
-s := repo.SubscriberAll(func(e eventsourcing.Event) {
+s := repo.EventStream.All(func(e eventsourcing.Event) {
     switch e := event.Data.(type) {
         case *FrequentFlierAccountCreated:
             // e now have type info

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ serializer.Register(&Person{}, serializer.Events(&Born{}, &AgedOneYear{}))
 
 The repository expose four possibilities to subscribe to events in realtime as they are saved to the repository.
 
-`All(func (e Event)) *subscription` subscribes to all event.
+`All(func (e Event)) *subscription` subscribes to all events.
 
 `AggregateID(func (e Event), events ...Aggregate) *subscription` events bound to specific aggregate based on type and identity.
 This makes it possible to get events pinpointed to one specific aggregate instance.

--- a/README.md
+++ b/README.md
@@ -310,7 +310,6 @@ The repository expose four possibilities to subscribe to events in realtime as t
 `Aggregate(func (e Event), events ...Aggregate) *subscription` events bound to specific aggregate based on type and identity.
 This makes it possible to get events pinpointed to one specific aggregate instance.
 
-
 `AggregateType(func (e Event), aggregates ...Aggregate) *subscription` subscribes to events bound to specific aggregate type. 
  
 `SpecificEvent(func (e Event), events ...interface{}) *subscription` subscribes to specific events. There are no restrictions that the events need
@@ -331,7 +330,7 @@ Example on how to set up the event subscription and consume the event `FrequentF
 repo := eventsourcing.NewRepository(memory.Create(), nil)
 
 // subscriber that will trigger on every saved events
-s := repo.EventStream.All(func(e eventsourcing.Event) {
+s := repo.Subscribers().All(func(e eventsourcing.Event) {
     switch e := event.Data.(type) {
         case *FrequentFlierAccountCreated:
             // e now have type info
@@ -340,11 +339,8 @@ s := repo.EventStream.All(func(e eventsourcing.Event) {
     }
 )
 
-// start subscription
-s.Subscribe()
-
 // stop subscription
-s.Unsubscribe() 
+s.Close()
 ```
 
 ## Custom made components

--- a/event.go
+++ b/event.go
@@ -23,6 +23,17 @@ type Event struct {
 	Metadata      map[string]interface{}
 }
 
+// EventUntyped holding meta data and the application specific event in the Data property
+type EventUntyped struct {
+	AggregateID   string
+	Version       Version
+	GlobalVersion Version
+	AggregateType string
+	Timestamp     time.Time
+	Data          map[string]interface{}
+	Metadata      map[string]interface{}
+}
+
 // Reason returns the name of the data struct
 func (e Event) Reason() string {
 	if e.Data == nil {

--- a/event.go
+++ b/event.go
@@ -1,6 +1,7 @@
 package eventsourcing
 
 import (
+	"encoding/json"
 	"errors"
 	"reflect"
 	"time"
@@ -29,4 +30,13 @@ func (e Event) Reason() string {
 		return ""
 	}
 	return reflect.TypeOf(e.Data).Elem().Name()
+}
+
+// DataAs convert the event.Data to the supplied type
+func (e Event) DataAs(i interface{}) error {
+	b, err := json.Marshal(e.Data)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, i)
 }

--- a/event.go
+++ b/event.go
@@ -23,17 +23,6 @@ type Event struct {
 	Metadata      map[string]interface{}
 }
 
-// EventUntyped holding meta data and the application specific event in the Data property
-type EventUntyped struct {
-	AggregateID   string
-	Version       Version
-	GlobalVersion Version
-	AggregateType string
-	Timestamp     time.Time
-	Data          map[string]interface{}
-	Metadata      map[string]interface{}
-}
-
 // Reason returns the name of the data struct
 func (e Event) Reason() string {
 	if e.Data == nil {

--- a/event.go
+++ b/event.go
@@ -32,7 +32,7 @@ func (e Event) Reason() string {
 	return reflect.TypeOf(e.Data).Elem().Name()
 }
 
-// DataAs convert the event.Data to the supplied type
+// DataAs convert the event.Data to the supplied type.
 func (e Event) DataAs(i interface{}) error {
 	b, err := json.Marshal(e.Data)
 	if err != nil {

--- a/event_test.go
+++ b/event_test.go
@@ -14,3 +14,26 @@ func TestEvent(t *testing.T) {
 		t.Fatalf("expected Born got %s", e.Reason())
 	}
 }
+
+func TestDataAs(t *testing.T) {
+	type Created struct {
+		Name string
+		Age int
+	}
+	b := Born {Name: "Jonathan"}
+	c := Created{}
+
+	e := eventsourcing.Event{
+		Data: &b,
+	}
+	err := e.DataAs(&c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Name != c.Name {
+		t.Fatal("Name should be the same")
+	}
+	if c.Age != 0 {
+		t.Fatal("Age should be int´s zero value")
+	}
+}

--- a/eventstream.go
+++ b/eventstream.go
@@ -117,8 +117,8 @@ func (e *EventStream) All(f func(e Event)) *subscription {
 	return &s
 }
 
-// Aggregate subscribe to events that belongs to aggregate's based on its type and ID
-func (e *EventStream) Aggregate(f func(e Event), aggregates ...Aggregate) *subscription {
+// AggregateID subscribe to events that belongs to aggregate's based on its type and ID
+func (e *EventStream) AggregateID(f func(e Event), aggregates ...Aggregate) *subscription {
 	s := subscription{
 		eventF: f,
 	}
@@ -145,8 +145,8 @@ func (e *EventStream) Aggregate(f func(e Event), aggregates ...Aggregate) *subsc
 	return &s
 }
 
-// AggregateType subscribe to events based on the aggregate type
-func (e *EventStream) AggregateType(f func(e Event), aggregates ...Aggregate) *subscription {
+// Aggregate subscribe to events based on the aggregate type
+func (e *EventStream) Aggregate(f func(e Event), aggregates ...Aggregate) *subscription {
 	s := subscription{
 		eventF: f,
 	}
@@ -173,7 +173,7 @@ func (e *EventStream) AggregateType(f func(e Event), aggregates ...Aggregate) *s
 	return &s
 }
 
-// Event subscribe on specific events where the interface is a pointer to the event struct
+// Event subscribe on specific application defined events based on type referencing.
 func (e *EventStream) Event(f func(e Event), events ...interface{}) *subscription {
 	s := subscription{
 		eventF: f,
@@ -198,7 +198,8 @@ func (e *EventStream) Event(f func(e Event), events ...interface{}) *subscriptio
 	return &s
 }
 
-// Name subscribe to aggregate and events names
+// Name subscribe to aggregate name combined with event names. The Name subscriber makes it possible to subscribe to
+// events event if the aggregate and event types are within the current application context.
 func (e *EventStream) Name(f func(e Event), aggregate string, events ...string) *subscription {
 	s := subscription{
 		eventF: f,

--- a/eventstream.go
+++ b/eventstream.go
@@ -6,53 +6,53 @@ import (
 	"sync"
 )
 
-// EventStream struct that handles event subscriptionEvent
+// EventStream struct that handles event subscription
 type EventStream struct {
 	// makes sure events are delivered in order and subscriptions are persistent
 	lock sync.Mutex
 
 	// subscribers that get types Events
 	// holds subscribers of aggregate types events
-	aggregateTypes map[string][]*subscriptionEvent
+	aggregateTypes map[string][]*subscription
 	// holds subscribers of specific aggregates (type and identifier)
-	specificAggregates map[string][]*subscriptionEvent
+	specificAggregates map[string][]*subscription
 	// holds subscribers of specific events
-	specificEvents map[reflect.Type][]*subscriptionEvent
+	specificEvents map[reflect.Type][]*subscription
 	// holds subscribers of all events
-	allEvents []*subscriptionEvent
+	allEvents []*subscription
 	// holds subscribers of aggregate types by name
-	aggregateTypesName map[string][]*subscriptionEvent
+	aggregateTypesName map[string][]*subscription
 	// subscribe to event reason
-	eventReason map[string][]*subscriptionEvent
+	eventReason map[string][]*subscription
 }
 
-// subscriptionEvent holding the subscribe / unsubscribe / and func to be called when
-// event matches the subscriptionEvent
-type subscriptionEvent struct {
+// subscription holding the subscribe / unsubscribe / and func to be called when
+// event matches the subscription
+type subscription struct {
 	eventF func(e Event)
 	unsubF func()
 	subF   func()
 }
 
-// Unsubscribe stops the subscriptionEvent
-func (s *subscriptionEvent) Unsubscribe() {
+// Unsubscribe stops the subscription
+func (s *subscription) Unsubscribe() {
 	s.unsubF()
 }
 
-// Subscribe starts the subscriptionEvent
-func (s *subscriptionEvent) Subscribe() {
+// Subscribe starts the subscription
+func (s *subscription) Subscribe() {
 	s.subF()
 }
 
 // NewEventStream factory function
 func NewEventStream() *EventStream {
 	return &EventStream{
-		aggregateTypes:     make(map[string][]*subscriptionEvent),
-		specificAggregates: make(map[string][]*subscriptionEvent),
-		specificEvents:     make(map[reflect.Type][]*subscriptionEvent),
-		allEvents:          make([]*subscriptionEvent, 0),
-		aggregateTypesName: make(map[string][]*subscriptionEvent),
-		eventReason:        make(map[string][]*subscriptionEvent),
+		aggregateTypes:     make(map[string][]*subscription),
+		specificAggregates: make(map[string][]*subscription),
+		specificEvents:     make(map[reflect.Type][]*subscription),
+		allEvents:          make([]*subscription, 0),
+		aggregateTypesName: make(map[string][]*subscription),
+		eventReason:        make(map[string][]*subscription),
 	}
 }
 
@@ -63,7 +63,6 @@ func (e *EventStream) Publish(agg AggregateRoot, events []Event) {
 	defer e.lock.Unlock()
 
 	for _, event := range events {
-		// types events
 		e.allEventPublisher(event)
 		e.specificEventPublisher(event)
 		e.aggregateTypePublisher(agg, event)
@@ -131,8 +130,8 @@ func (e *EventStream) eventReasonSubscriberUntyped(event Event) {
 }
 
 // SubscriberAll bind the eventF function to be called on all events independent on aggregate or event type
-func (e *EventStream) SubscriberAll(f func(e Event)) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberAll(f func(e Event)) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {
@@ -156,8 +155,8 @@ func (e *EventStream) SubscriberAll(f func(e Event)) *subscriptionEvent {
 }
 
 // SubscriberSpecificAggregate bind the eventF function to be called on events that belongs to aggregate based on type and ID
-func (e *EventStream) SubscriberSpecificAggregate(f func(e Event), aggregates ...Aggregate) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberSpecificAggregate(f func(e Event), aggregates ...Aggregate) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {
@@ -193,8 +192,8 @@ func (e *EventStream) SubscriberSpecificAggregate(f func(e Event), aggregates ..
 }
 
 // SubscriberAggregateType bind the eventF function to be called on events on the aggregate type
-func (e *EventStream) SubscriberAggregateType(f func(e Event), aggregates ...Aggregate) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberAggregateType(f func(e Event), aggregates ...Aggregate) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {
@@ -230,8 +229,8 @@ func (e *EventStream) SubscriberAggregateType(f func(e Event), aggregates ...Agg
 }
 
 // SubscriberSpecificEvent bind the eventF function to be called on specific events
-func (e *EventStream) SubscriberSpecificEvent(f func(e Event), events ...interface{}) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberSpecificEvent(f func(e Event), events ...interface{}) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {
@@ -263,8 +262,8 @@ func (e *EventStream) SubscriberSpecificEvent(f func(e Event), events ...interfa
 }
 
 // SubscriberAggregateTypeUntyped bind the eventF function to be called on events on the aggregate type
-func (e *EventStream) SubscriberAggregateTypeUntyped(f func(e Event), aggregateTypes ...string) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberAggregateTypeUntyped(f func(e Event), aggregateTypes ...string) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {
@@ -292,8 +291,8 @@ func (e *EventStream) SubscriberAggregateTypeUntyped(f func(e Event), aggregateT
 }
 
 // SubscriberEventReasonUntyped bind the eventF function to be called on event reason
-func (e *EventStream) SubscriberEventReasonUntyped(f func(e Event), eventReasons ...string) *subscriptionEvent {
-	s := subscriptionEvent{
+func (e *EventStream) SubscriberEventReasonUntyped(f func(e Event), eventReasons ...string) *subscription {
+	s := subscription{
 		eventF: f,
 	}
 	s.unsubF = func() {

--- a/eventstream.go
+++ b/eventstream.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 )
 
-// EventStream struct what handles event subscriptionEvent
+// EventStream struct that handles event subscriptionEvent
 type EventStream struct {
 	// makes sure events are delivered in order and subscriptions are persistent
 	lock sync.Mutex

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -247,7 +247,7 @@ func TestParallelUpdates(t *testing.T) {
 	streamEvent := make([]eventsourcing.Event, 0)
 	e := eventsourcing.NewEventStream()
 
-	// functions to bind to event subscriptionEvent
+	// functions to bind to event subscription
 	f1 := func(e eventsourcing.Event) {
 		streamEvent = append(streamEvent, e)
 	}

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -297,21 +297,23 @@ func TestClose(t *testing.T) {
 	s2 := e.Event(f, &AnEvent{})
 	s3 := e.AggregateType(f, &AnAggregate{})
 	s4 := e.Aggregate(f, &AnAggregate{})
+	s5 := e.All(f)
 
 	// trigger 4 subscriptions
 	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
-	if count != 4 {
-		t.Fatalf("should have received four event")
+	if count != 5 {
+		t.Fatalf("should have received 5 event")
 	}
 	// close all subscriptions
 	s1.Close()
 	s2.Close()
 	s3.Close()
 	s4.Close()
+	s5.Close()
 
 	// new event should not trigger closed subscriptions
 	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
-	if count != 4 {
+	if count != 5 {
 		t.Fatalf("should not have received event after subscriptions are closed")
 	}
 }

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -326,7 +326,7 @@ func TestClose(t *testing.T) {
 	}
 }
 
-func TestAllAsUntyped(t *testing.T) {
+func TestAllUntyped(t *testing.T) {
 	var streamEvent eventsourcing.EventUntyped
 	e := eventsourcing.NewEventStream()
 	f := func(e eventsourcing.EventUntyped) {
@@ -345,5 +345,37 @@ func TestAllAsUntyped(t *testing.T) {
 	}
 	if streamEvent.Data["Name"] != "123" {
 		t.Fatalf("wrong name")
+	}
+}
+
+func TestAggregateTypeUntyped(t *testing.T) {
+	var streamEvent eventsourcing.EventUntyped
+	var count int
+	e := eventsourcing.NewEventStream()
+	f := func(e eventsourcing.EventUntyped) {
+		count++
+		streamEvent = e
+	}
+	s := e.SubscriberAggregateTypeUntyped(f, "AnAggregate")
+	s.Subscribe()
+	defer s.Unsubscribe()
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+
+	if streamEvent.Version != event.Version {
+		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, event.Version)
+	}
+	if streamEvent.Data == nil {
+		t.Fatalf("should have received event data")
+	}
+	if streamEvent.Data["Name"] != "123" {
+		t.Fatalf("wrong name")
+	}
+	streamEvent = eventsourcing.EventUntyped{}
+	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
+	if streamEvent.Version != 0 {
+		t.Fatalf("expected zero value")
+	}
+	if count != 1 {
+		t.Fatalf("expected the event function to be hit once")
 	}
 }

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -326,33 +326,11 @@ func TestClose(t *testing.T) {
 	}
 }
 
-func TestAllUntyped(t *testing.T) {
-	var streamEvent eventsourcing.EventUntyped
-	e := eventsourcing.NewEventStream()
-	f := func(e eventsourcing.EventUntyped) {
-		streamEvent = e
-	}
-	s := e.SubscriberAllUntyped(f)
-	s.Subscribe()
-	defer s.Unsubscribe()
-	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
-
-	if streamEvent.Version != event.Version {
-		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, event.Version)
-	}
-	if streamEvent.Data == nil {
-		t.Fatalf("should have received event data")
-	}
-	if streamEvent.Data["Name"] != "123" {
-		t.Fatalf("wrong name")
-	}
-}
-
-func TestAggregateTypeUntyped(t *testing.T) {
-	var streamEvent eventsourcing.EventUntyped
+func TestAggregateType(t *testing.T) {
+	var streamEvent eventsourcing.Event
 	var count int
 	e := eventsourcing.NewEventStream()
-	f := func(e eventsourcing.EventUntyped) {
+	f := func(e eventsourcing.Event) {
 		count++
 		streamEvent = e
 	}
@@ -367,10 +345,8 @@ func TestAggregateTypeUntyped(t *testing.T) {
 	if streamEvent.Data == nil {
 		t.Fatalf("should have received event data")
 	}
-	if streamEvent.Data["Name"] != "123" {
-		t.Fatalf("wrong name")
-	}
-	streamEvent = eventsourcing.EventUntyped{}
+
+	streamEvent = eventsourcing.Event{}
 	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != 0 {
 		t.Fatalf("expected zero value")
@@ -380,11 +356,11 @@ func TestAggregateTypeUntyped(t *testing.T) {
 	}
 }
 
-func TestEventReasonUntyped(t *testing.T) {
-	var streamEvent eventsourcing.EventUntyped
+func TestEventReason(t *testing.T) {
+	var streamEvent eventsourcing.Event
 	var count int
 	e := eventsourcing.NewEventStream()
-	f := func(e eventsourcing.EventUntyped) {
+	f := func(e eventsourcing.Event) {
 		count++
 		streamEvent = e
 	}
@@ -399,10 +375,8 @@ func TestEventReasonUntyped(t *testing.T) {
 	if streamEvent.Data == nil {
 		t.Fatalf("should have received event data")
 	}
-	if streamEvent.Data["Name"] != "123" {
-		t.Fatalf("wrong name")
-	}
-	streamEvent = eventsourcing.EventUntyped{}
+
+	streamEvent = eventsourcing.Event{}
 	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != 0 {
 		t.Fatalf("expected zero value")

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -332,7 +332,7 @@ func TestAllAsUntyped(t *testing.T) {
 	f := func(e eventsourcing.EventUntyped) {
 		streamEvent = e
 	}
-	s := e.SubscriberAllAsMap(f)
+	s := e.SubscriberAllUntyped(f)
 	s.Subscribe()
 	defer s.Unsubscribe()
 	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -37,7 +37,7 @@ func TestAll(t *testing.T) {
 	s := e.SubscriberAll(f)
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
@@ -56,7 +56,7 @@ func TestSubscribeOneEvent(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
@@ -84,7 +84,7 @@ func TestSubscriberSpecificAggregate(t *testing.T) {
 	s.Subscribe()
 	defer s.Unsubscribe()
 	// update with event from the AnAggregate aggregate
-	e.Update(anAggregate.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(anAggregate.AggregateRoot, []eventsourcing.Event{event})
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
@@ -93,7 +93,7 @@ func TestSubscriberSpecificAggregate(t *testing.T) {
 	}
 
 	// update with event from the AnotherAggregate aggregate
-	e.Update(anOtherAggregate.AggregateRoot, []eventsourcing.Event{otherEvent})
+	e.Publish(anOtherAggregate.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != otherEvent.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, otherEvent.Version)
 	}
@@ -110,7 +110,7 @@ func TestSubscribeAggregateType(t *testing.T) {
 	defer s.Unsubscribe()
 
 	// update with event from the AnAggregate aggregate
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if streamEvent == nil {
 		t.Fatalf("should have received event")
 	}
@@ -119,7 +119,7 @@ func TestSubscribeAggregateType(t *testing.T) {
 	}
 
 	// update with event from the AnotherAggregate aggregate
-	e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
+	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 	if streamEvent.Version != otherEvent.Version {
 		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, otherEvent.Version)
 	}
@@ -134,8 +134,8 @@ func TestSubscribeToManyEvents(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnEvent{}, &AnotherEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
-	e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
 
 	if streamEvents == nil {
 		t.Fatalf("should have received event")
@@ -155,6 +155,14 @@ func TestSubscribeToManyEvents(t *testing.T) {
 		t.Fatalf("expecting OtherEvent got %q", ev)
 	}
 
+	type AnEvent2 struct {
+		Name string
+	}
+	switch ev := streamEvents[0].Data.(type) {
+	case *AnEvent2:
+		t.Fatalf("expecting AnEvent got %q", ev)
+	}
+
 }
 
 func TestUpdateNoneSubscribedEvent(t *testing.T) {
@@ -166,7 +174,7 @@ func TestUpdateNoneSubscribedEvent(t *testing.T) {
 	s := e.SubscriberSpecificEvent(f, &AnotherEvent{})
 	s.Subscribe()
 	defer s.Unsubscribe()
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if streamEvent != nil {
 		t.Fatalf("should not have received event %q", streamEvent)
@@ -212,7 +220,7 @@ func TestManySubscribers(t *testing.T) {
 	s.Subscribe()
 	defer s.Unsubscribe()
 
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 
 	if len(streamEvent1) != 0 {
 		t.Fatalf("stream1 should not have any events")
@@ -261,11 +269,11 @@ func TestParallelUpdates(t *testing.T) {
 	for i := 1; i < 1000; i++ {
 		wg.Add(2)
 		go func() {
-			e.Update(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent, otherEvent})
+			e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent, otherEvent})
 			wg.Done()
 		}()
 		go func() {
-			e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event, event})
+			e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event, event})
 			wg.Done()
 		}()
 	}
@@ -301,7 +309,7 @@ func TestClose(t *testing.T) {
 	s4.Subscribe()
 
 	// trigger all 4 subscriptions
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if count != 4 {
 		t.Fatalf("should have received four event")
 	}
@@ -312,7 +320,7 @@ func TestClose(t *testing.T) {
 	s4.Unsubscribe()
 
 	// new event should not trigger closed subscriptions
-	e.Update(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
 	if count != 4 {
 		t.Fatalf("should not have received event after subscriptions are closed")
 	}

--- a/eventstream_test.go
+++ b/eventstream_test.go
@@ -379,3 +379,35 @@ func TestAggregateTypeUntyped(t *testing.T) {
 		t.Fatalf("expected the event function to be hit once")
 	}
 }
+
+func TestEventReasonUntyped(t *testing.T) {
+	var streamEvent eventsourcing.EventUntyped
+	var count int
+	e := eventsourcing.NewEventStream()
+	f := func(e eventsourcing.EventUntyped) {
+		count++
+		streamEvent = e
+	}
+	s := e.SubscriberEventReasonUntyped(f, "AnEvent")
+	s.Subscribe()
+	defer s.Unsubscribe()
+	e.Publish(AnAggregate{}.AggregateRoot, []eventsourcing.Event{event})
+
+	if streamEvent.Version != event.Version {
+		t.Fatalf("wrong info in event got %q expected %q", streamEvent.Version, event.Version)
+	}
+	if streamEvent.Data == nil {
+		t.Fatalf("should have received event data")
+	}
+	if streamEvent.Data["Name"] != "123" {
+		t.Fatalf("wrong name")
+	}
+	streamEvent = eventsourcing.EventUntyped{}
+	e.Publish(AnotherAggregate{}.AggregateRoot, []eventsourcing.Event{otherEvent})
+	if streamEvent.Version != 0 {
+		t.Fatalf("expected zero value")
+	}
+	if count != 1 {
+		t.Fatalf("expected the event function to be hit once")
+	}
+}

--- a/repository.go
+++ b/repository.go
@@ -32,8 +32,8 @@ type Aggregate interface {
 
 type EventSubscribers interface {
 	All(f func(e Event)) *subscription
+	AggregateID(f func(e Event), aggregates ...Aggregate) *subscription
 	Aggregate(f func(e Event), aggregates ...Aggregate) *subscription
-	AggregateType(f func(e Event), aggregates ...Aggregate) *subscription
 	Event(f func(e Event), events ...interface{}) *subscription
 	Name(f func(e Event), aggregate string, events ...string) *subscription
 }

--- a/repository.go
+++ b/repository.go
@@ -38,7 +38,7 @@ var ErrAggregateNotFound = errors.New("aggregate not found")
 
 // Repository is the returned instance from the factory function
 type Repository struct {
-	*EventStream
+	EventStream *EventStream
 	eventStore EventStore
 	snapshot   *SnapshotHandler
 }
@@ -61,7 +61,7 @@ func (r *Repository) Save(aggregate Aggregate) error {
 		return err
 	}
 	// publish the saved events to subscribers
-	r.Publish(*root, root.Events())
+	r.EventStream.Publish(*root, root.Events())
 
 	// update the internal aggregate state
 	root.update()

--- a/repository.go
+++ b/repository.go
@@ -55,13 +55,13 @@ func NewRepository(eventStore EventStore, snapshot *SnapshotHandler) *Repository
 // Save an aggregates events
 func (r *Repository) Save(aggregate Aggregate) error {
 	root := aggregate.Root()
-	// use underlaying event slice to set GlobalVersion
+	// use under laying event slice to set GlobalVersion
 	err := r.eventStore.Save(root.aggregateEvents)
 	if err != nil {
 		return err
 	}
 	// publish the saved events to subscribers
-	r.Update(*root, root.Events())
+	r.Publish(*root, root.Events())
 
 	// update the internal aggregate state
 	root.update()

--- a/repository_test.go
+++ b/repository_test.go
@@ -354,7 +354,7 @@ func TestEventChainDoesNotHang(t *testing.T) {
 		close(doneChan)
 	}()
 
-	// create the initial person and setup event subscription on the specific person events
+	// create the initial person and setup event subscriptionEvent on the specific person events
 	person, err := CreatePerson("kalle")
 	if err != nil {
 		t.Fatal(err)

--- a/repository_test.go
+++ b/repository_test.go
@@ -271,13 +271,13 @@ func TestSubscriptionSpecificEvent(t *testing.T) {
 	}
 }
 
-func TestSubscriptionAggregateType(t *testing.T) {
+func TestSubscriptionAggregate(t *testing.T) {
 	counter := 0
 	f := func(e eventsourcing.Event) {
 		counter++
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
-	s := repo.Subscribers().AggregateType(f, &Person{})
+	s := repo.Subscribers().Aggregate(f, &Person{})
 	defer s.Close()
 
 	person, err := CreatePerson("kalle")
@@ -308,7 +308,7 @@ func TestSubscriptionSpecificAggregate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := repo.Subscribers().Aggregate(f, person)
+	s := repo.Subscribers().AggregateID(f, person)
 	defer s.Close()
 
 	person.GrowOlder()
@@ -355,7 +355,7 @@ func TestEventChainDoesNotHang(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := repo.Subscribers().Aggregate(f, person)
+	s := repo.Subscribers().AggregateID(f, person)
 	defer s.Close()
 
 	// subscribe to all events and filter out AgedOneYear

--- a/repository_test.go
+++ b/repository_test.go
@@ -354,7 +354,7 @@ func TestEventChainDoesNotHang(t *testing.T) {
 		close(doneChan)
 	}()
 
-	// create the initial person and setup event subscriptionEvent on the specific person events
+	// create the initial person and setup event subscription on the specific person events
 	person, err := CreatePerson("kalle")
 	if err != nil {
 		t.Fatal(err)

--- a/repository_test.go
+++ b/repository_test.go
@@ -225,7 +225,7 @@ func TestSubscriptionAllEvent(t *testing.T) {
 		counter++
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
-	s := repo.SubscriberAll(f)
+	s := repo.EventStream.All(f)
 	s.Subscribe()
 	defer s.Unsubscribe()
 
@@ -252,7 +252,7 @@ func TestSubscriptionSpecificEvent(t *testing.T) {
 		counter++
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
-	s := repo.SubscriberSpecificEvent(f, &Born{}, &AgedOneYear{})
+	s := repo.EventStream.SpecificEvent(f, &Born{}, &AgedOneYear{})
 	s.Subscribe()
 	defer s.Unsubscribe()
 
@@ -279,7 +279,7 @@ func TestSubscriptionAggregateType(t *testing.T) {
 		counter++
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
-	s := repo.SubscriberAggregateType(f, &Person{})
+	s := repo.EventStream.AggregateType(f, &Person{})
 	s.Subscribe()
 	defer s.Unsubscribe()
 
@@ -311,7 +311,7 @@ func TestSubscriptionSpecificAggregate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := repo.SubscriberSpecificAggregate(f, person)
+	s := repo.EventStream.Aggregate(f, person)
 	s.Subscribe()
 	defer s.Unsubscribe()
 
@@ -359,13 +359,13 @@ func TestEventChainDoesNotHang(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	s := repo.SubscriberSpecificAggregate(f, person)
+	s := repo.EventStream.Aggregate(f, person)
 	s.Subscribe()
 	defer s.Unsubscribe()
 
 	// subscribe to all events and filter out AgedOneYear
 	ageCounter := 0
-	s2 := repo.SubscriberAll(func(e eventsourcing.Event) {
+	s2 := repo.EventStream.All(func(e eventsourcing.Event) {
 		switch e.Data.(type) {
 		case *AgedOneYear:
 			// will match three times on the initial person and one each on the resulting AgedOneYear event

--- a/repository_test.go
+++ b/repository_test.go
@@ -226,8 +226,7 @@ func TestSubscriptionAllEvent(t *testing.T) {
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
 	s := repo.EventStream.All(f)
-	s.Subscribe()
-	defer s.Unsubscribe()
+	defer s.Close()
 
 	person, err := CreatePerson("kalle")
 	if err != nil {
@@ -253,8 +252,7 @@ func TestSubscriptionSpecificEvent(t *testing.T) {
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
 	s := repo.EventStream.SpecificEvent(f, &Born{}, &AgedOneYear{})
-	s.Subscribe()
-	defer s.Unsubscribe()
+	defer s.Close()
 
 	person, err := CreatePerson("kalle")
 	if err != nil {
@@ -280,8 +278,7 @@ func TestSubscriptionAggregateType(t *testing.T) {
 	}
 	repo := eventsourcing.NewRepository(memory.Create(), nil)
 	s := repo.EventStream.AggregateType(f, &Person{})
-	s.Subscribe()
-	defer s.Unsubscribe()
+	defer s.Close()
 
 	person, err := CreatePerson("kalle")
 	if err != nil {
@@ -312,8 +309,7 @@ func TestSubscriptionSpecificAggregate(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := repo.EventStream.Aggregate(f, person)
-	s.Subscribe()
-	defer s.Unsubscribe()
+	defer s.Close()
 
 	person.GrowOlder()
 	person.GrowOlder()
@@ -360,8 +356,7 @@ func TestEventChainDoesNotHang(t *testing.T) {
 		t.Fatal(err)
 	}
 	s := repo.EventStream.Aggregate(f, person)
-	s.Subscribe()
-	defer s.Unsubscribe()
+	defer s.Close()
 
 	// subscribe to all events and filter out AgedOneYear
 	ageCounter := 0
@@ -372,8 +367,7 @@ func TestEventChainDoesNotHang(t *testing.T) {
 			ageCounter++
 		}
 	})
-	s2.Subscribe()
-	defer s2.Unsubscribe()
+	defer s2.Close()
 
 	person.GrowOlder()
 	person.GrowOlder()


### PR DESCRIPTION
When different parts of an application wants to subscribe to events from the repository but don't want to reference the specific aggregate or event types. ~~Instead of returning the `eventsourcing.Event` a new type is introduced `eventsourcing.EventUntyped`. This new type is the same as `eventsourcing.Event` but the `Data` property is a `map[string]interface{}` instead of an `interface{}`. This makes it possible to handle the events in an untyped form without the typed application events.~~ New methods is introduced making it possible to subscribe by aggregate and event names. The `eventsourcing.Event` expose a `DataAs(i interface{}) error` where the `Data` property on the event can be transformed to a new type. 

The idea came from the book Strategic Monoliths and Microservices and the concept of a modular monolith. If different bounded context wants to subscribe to events from different bounded contexts, they should not know and reference internal types from others.