### PR TITLE
RegisterEvents method on the aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,20 @@ Register the aggregate Person and the events Born and AgedOneYear (Makes use of 
 serializer.Register(&Person{}, serializer.Events(&Born{}, &AgedOneYear{}))
 ```
 
+A problem with the above way of register the aggregate and its events is when new events are introduced. As the registration to the serializer is apart from the definition of the events it's easy to miss register them to the serializer. A solution to this is the optional callback function `RegisterEvents` that can be defined on the aggregate. This function is called by the serializer when an aggregate is registered via the `RegisterAggregate` method.
+
+```go
+func (s *Person) RegisterEvents(f eventsourcing.EventsFunc) error {
+	return f(
+		&Born{},
+        &AgedOneYear{},
+	)
+}
+
+s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
+s.RegisterAggregate(&Person{}) // will call the RegisterEvents function on the Person aggregate.
+```
+
 ### Event Subscription
 
 The repository expose four possibilities to subscribe to events in realtime as they are saved to the repository.

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -12,7 +12,7 @@ import (
 func initSerializers(t *testing.T) []*eventsourcing.Serializer {
 	var result []*eventsourcing.Serializer
 	s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
-	err := s.Register(&SomeAggregate{}, s.Events(&SomeData{}, &SomeData2{}))
+	err := s.RegisterAggregate(&SomeAggregate{})
 	if err != nil {
 		t.Fatalf("could not register aggregate events %v", err)
 	}
@@ -25,6 +25,13 @@ type SomeAggregate struct {
 }
 
 func (s *SomeAggregate) Transition(event eventsourcing.Event) {}
+
+func (s *SomeAggregate) RegisterEvents(f eventsourcing.EventsFunc) error {
+	return f(
+		&SomeData{},
+		&SomeData2{},
+	)
+}
 
 type SomeData struct {
 	A int

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -70,11 +70,10 @@ func TestSerializeDeserialize(t *testing.T) {
 				t.Fatalf("Could not Unmarshal data, %v", err)
 			}
 
-			/*
-				if data2.A != data.A {
-					t.Fatalf("wrong value in A expected: %d, actual: %d", data.A, data2.A)
-				}
-			*/
+			if data2.(*SomeData).A != data.A {
+				t.Fatalf("wrong value in A expected: %d, actual: %d", data.A, data2.(*SomeData).A)
+			}
+
 			m, err := s.Marshal(metaData)
 			if err != nil {
 				t.Fatalf("could not Marshal metadata, %v", err)


### PR DESCRIPTION
The current way to register aggregate event to the serialiser is via methods on the serialiser entity.

```go
s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
err := s.Register(&SomeAggregate{}, ser.Event(&SomeData{}))
```

By adding events to the serialiser appart from the aggregate code makes it easy to miss register newly added events. This will have the effect that the event will not be handled in aggregate `Transition(event eventsourcing.Event)` method when building the aggregate from events that are fetched from the eventstore. By adding a new optional method `RegisterEvents` on the aggregate this makes it's harder to miss.

```go
// new method on the aggregate that will be called when using the steriliser method RegisterAggregate
func (s *SomeAggregate) RegisterEvents(f eventsourcing.EventsFunc) error {
	return f(
		&SomeData{},
	)
}

s := eventsourcing.NewSerializer(json.Marshal, json.Unmarshal)
err := s.RegisterAggregate(&SomeAggregate{})
```

The already existing serialiser registration methods will works as before. This will hopefully make the aggregate/event work more contained.