### PR TITLE
Better handling contexts

### DIFF
--- a/eventstore/esdb/esdb.go
+++ b/eventstore/esdb/esdb.go
@@ -89,8 +89,6 @@ func (es *ESDB) Get(ctx context.Context, id string, aggregateType string, afterV
 			}
 		}
 		return nil, err
-	} else if ctx.Err() != nil {
-		return nil, ctx.Err()
 	}
 	return &iterator{stream: stream}, nil
 }

--- a/eventstore/sql/sql.go
+++ b/eventstore/sql/sql.go
@@ -84,11 +84,8 @@ func (s *SQL) Get(ctx context.Context, id string, aggregateType string, afterVer
 	rows, err := s.db.QueryContext(ctx, selectStm, id, aggregateType, afterVersion)
 	if err != nil {
 		return nil, err
-	} else if ctx.Err() != nil {
-		return nil, ctx.Err()
 	}
-	i := iterator{rows: rows}
-	return &i, nil
+	return &iterator{rows: rows}, nil
 }
 
 // GlobalEvents return count events in order globally from the start posistion

--- a/repository.go
+++ b/repository.go
@@ -149,10 +149,9 @@ func (r *Repository) GetWithContext(ctx context.Context, id string, a aggregate)
 	} else if errors.Is(err, core.ErrNoEvents) && root.Version() == 0 {
 		// no events and not based on a snapshot
 		return ErrAggregateNotFound
-	} else if ctx.Err() != nil {
-		return ctx.Err()
 	}
 	defer eventIterator.Close()
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
In the current implementation there is a risk of resource leak.