### PR TITLE
Iterator interface re-design

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,10 @@ The only thing an event store handles are events, and it must implement the foll
 
 ```go
 // saves events to the under laying data store.
-Save(events []eventsourcing.Event) error
+Save(events []core.Event) error
 
 // fetches events based on identifier and type but also after a specific version. The version is used to load event that happened after a snapshot was taken.
-Get(id string, aggregateType string, afterVersion eventsourcing.Version) (eventsourcing.Iterator, error)
+Get(id string, aggregateType string, afterVersion core.Version) (core.Iterator, error)
 ```
 
 Currently, there are three implementations.

--- a/core/eventstore.go
+++ b/core/eventstore.go
@@ -16,7 +16,8 @@ var ErrConcurrency = errors.New("concurrency error")
 
 // Iterator is the interface an event store Get needs to return
 type Iterator interface {
-	Next() (Event, error)
+	Next() bool
+	Value() (Event, error)
 	Close()
 }
 

--- a/core/eventstore.go
+++ b/core/eventstore.go
@@ -5,12 +5,6 @@ import (
 	"errors"
 )
 
-// ErrNoEvents when there is no events to get
-var ErrNoEvents = errors.New("no events")
-
-// ErrNoMoreEvents when iterator has no more events to deliver
-var ErrNoMoreEvents = errors.New("no more events")
-
 // ErrConcurrency when the currently saved version of the aggregate differs from the new ones
 var ErrConcurrency = errors.New("concurrency error")
 

--- a/core/nopiterator.go
+++ b/core/nopiterator.go
@@ -1,16 +1,16 @@
 package core
 
-// NopIterator returns no data
-type NopIterator struct{}
+// ZeroIterator returns no data
+type ZeroIterator struct{}
 
-func (ni NopIterator) Next() bool {
+func (ni ZeroIterator) Next() bool {
 	return false
 }
 
-func (ni NopIterator) Value() (Event, error) {
+func (ni ZeroIterator) Value() (Event, error) {
 	return Event{}, nil
 }
 
-func (ni NopIterator) Close() {
+func (ni ZeroIterator) Close() {
 	return
 }

--- a/core/nopiterator.go
+++ b/core/nopiterator.go
@@ -1,0 +1,16 @@
+package core
+
+// NopIterator returns no data
+type NopIterator struct{}
+
+func (ni NopIterator) Next() bool {
+	return false
+}
+
+func (ni NopIterator) Value() (Event, error) {
+	return Event{}, nil
+}
+
+func (ni NopIterator) Close() {
+	return
+}

--- a/core/testsuite/suite.go
+++ b/core/testsuite/suite.go
@@ -123,9 +123,6 @@ func saveAndGetEvents(es core.EventStore) error {
 	}
 	for iterator.Next() {
 		event, err := iterator.Value()
-		if errors.Is(err, core.ErrNoMoreEvents) {
-			break
-		}
 		if err != nil {
 			return err
 		}

--- a/core/testsuite/suite.go
+++ b/core/testsuite/suite.go
@@ -281,15 +281,11 @@ func getErrWhenNoEvents(es core.EventStore) error {
 	aggregateID := AggregateID()
 	iterator, err := es.Get(context.Background(), aggregateID, aggregateType, 0)
 	if err != nil {
-		if err != core.ErrNoEvents {
-			return err
-		}
-		return nil
+		return err
 	}
 	defer iterator.Close()
-	_, err = iterator.Value()
-	if !errors.Is(err, core.ErrNoMoreEvents) {
-		return fmt.Errorf("expect error when no events are saved for aggregate")
+	if iterator.Next() {
+		return fmt.Errorf("expect no event when no events are saved")
 	}
 	return nil
 }

--- a/core/testsuite/suite.go
+++ b/core/testsuite/suite.go
@@ -121,8 +121,8 @@ func saveAndGetEvents(es core.EventStore) error {
 	if err != nil {
 		return err
 	}
-	for {
-		event, err := iterator.Next()
+	for iterator.Next() {
+		event, err := iterator.Value()
 		if errors.Is(err, core.ErrNoMoreEvents) {
 			break
 		}
@@ -150,8 +150,8 @@ func saveAndGetEvents(es core.EventStore) error {
 	if err != nil {
 		return err
 	}
-	for {
-		event, err := iterator.Next()
+	for iterator.Next() {
+		event, err := iterator.Value()
 		if err != nil {
 			break
 		}
@@ -194,8 +194,8 @@ func getEventsAfterVersion(es core.EventStore) error {
 		return err
 	}
 
-	for {
-		event, err := iterator.Next()
+	for iterator.Next() {
+		event, err := iterator.Value()
 		if err != nil {
 			break
 		}
@@ -256,8 +256,8 @@ func saveAndGetEventsConcurrently(es core.EventStore) error {
 				return
 			}
 			events := make([]core.Event, 0)
-			for {
-				event, err := iterator.Next()
+			for iterator.Next() {
+				event, err := iterator.Value()
 				if err != nil {
 					break
 				}
@@ -287,7 +287,7 @@ func getErrWhenNoEvents(es core.EventStore) error {
 		return nil
 	}
 	defer iterator.Close()
-	_, err = iterator.Next()
+	_, err = iterator.Value()
 	if !errors.Is(err, core.ErrNoMoreEvents) {
 		return fmt.Errorf("expect error when no events are saved for aggregate")
 	}

--- a/eventstore/bbolt/go.mod
+++ b/eventstore/bbolt/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/sys v0.10.0 // indirect
 )
 
-//replace github.com/hallgren/eventsourcing/core => ../../core
+replace github.com/hallgren/eventsourcing/core => ../../core

--- a/eventstore/esdb/esdb.go
+++ b/eventstore/esdb/esdb.go
@@ -85,7 +85,7 @@ func (es *ESDB) Get(ctx context.Context, id string, aggregateType string, afterV
 	if err != nil {
 		if err, ok := esdb.FromError(err); !ok {
 			if err.Code() == esdb.ErrorCodeResourceNotFound {
-				return nil, core.ErrNoEvents
+				return core.NopIterator{}, nil
 			}
 		}
 		return nil, err

--- a/eventstore/esdb/esdb.go
+++ b/eventstore/esdb/esdb.go
@@ -85,7 +85,7 @@ func (es *ESDB) Get(ctx context.Context, id string, aggregateType string, afterV
 	if err != nil {
 		if err, ok := esdb.FromError(err); !ok {
 			if err.Code() == esdb.ErrorCodeResourceNotFound {
-				return core.NopIterator{}, nil
+				return core.ZeroIterator{}, nil
 			}
 		}
 		return nil, err

--- a/eventstore/esdb/go.mod
+++ b/eventstore/esdb/go.mod
@@ -11,4 +11,4 @@ require (
 	google.golang.org/grpc v1.57.0 // indirect
 )
 
-//replace github.com/hallgren/eventsourcing/core => ../../core
+replace github.com/hallgren/eventsourcing/core => ../../core

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -17,22 +17,20 @@ type Memory struct {
 type iterator struct {
 	events   []core.Event
 	position int
+	event    core.Event
 }
 
 func (i *iterator) Next() bool {
 	if len(i.events) <= i.position {
 		return false
 	}
+	i.event = i.events[i.position]
+	i.position++
 	return true
 }
 
 func (i *iterator) Value() (core.Event, error) {
-	if len(i.events) <= i.position {
-		return core.Event{}, core.ErrNoMoreEvents
-	}
-	event := i.events[i.position]
-	i.position++
-	return event, nil
+	return i.event, nil
 }
 
 func (i *iterator) Close() {

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -19,7 +19,14 @@ type iterator struct {
 	position int
 }
 
-func (i *iterator) Next() (core.Event, error) {
+func (i *iterator) Next() bool {
+	if len(i.events) <= i.position {
+		return false
+	}
+	return true
+}
+
+func (i *iterator) Value() (core.Event, error) {
 	if len(i.events) <= i.position {
 		return core.Event{}, core.ErrNoMoreEvents
 	}

--- a/eventstore/memory/memory.go
+++ b/eventstore/memory/memory.go
@@ -103,9 +103,6 @@ func (e *Memory) Get(ctx context.Context, id string, aggregateType string, after
 			events = append(events, e)
 		}
 	}
-	if len(events) == 0 {
-		return nil, core.ErrNoEvents
-	}
 	return &iterator{events: events}, nil
 }
 

--- a/eventstore/sql/go.mod
+++ b/eventstore/sql/go.mod
@@ -12,4 +12,4 @@ require (
 	github.com/ziutek/mymysql v1.5.4 // indirect
 )
 
-//replace github.com/hallgren/eventsourcing/core => ../../core
+replace github.com/hallgren/eventsourcing/core => ../../core

--- a/eventstore/sql/iterator.go
+++ b/eventstore/sql/iterator.go
@@ -11,18 +11,18 @@ type iterator struct {
 	rows *sql.Rows
 }
 
-// Next return the next event
-func (i *iterator) Next() (core.Event, error) {
+// Next return true if there are more data
+func (i *iterator) Next() bool {
+	return i.rows.Next()
+}
+
+// Value return the an event
+func (i *iterator) Value() (core.Event, error) {
 	var globalVersion core.Version
 	var version core.Version
 	var id, reason, typ, timestamp string
 	var data, metadata []byte
-	if !i.rows.Next() {
-		if err := i.rows.Err(); err != nil {
-			return core.Event{}, err
-		}
-		return core.Event{}, core.ErrNoMoreEvents
-	}
+
 	if err := i.rows.Scan(&globalVersion, &id, &version, &reason, &typ, &timestamp, &data, &metadata); err != nil {
 		return core.Event{}, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require github.com/hallgren/eventsourcing/core v0.2.0
 
-//replace github.com/hallgren/eventsourcing/core => ./core
+replace github.com/hallgren/eventsourcing/core => ./core

--- a/repository.go
+++ b/repository.go
@@ -75,7 +75,6 @@ func (r *Repository) Subscribers() EventSubscribers {
 
 // Save an aggregates events
 func (r *Repository) Save(a aggregate) error {
-	// TODO: check that the aggregate is registered before saving it?
 	if !r.register.AggregateRegistered(a) {
 		return ErrAggregateNotRegistered
 	}

--- a/repository.go
+++ b/repository.go
@@ -144,11 +144,8 @@ func (r *Repository) GetWithContext(ctx context.Context, id string, a aggregate)
 	aggregateType := aggregateType(a)
 	// fetch events after the current version of the aggregate that could be fetched from the snapshot store
 	eventIterator, err := r.eventStore.Get(ctx, id, aggregateType, core.Version(root.aggregateVersion))
-	if err != nil && !errors.Is(err, core.ErrNoEvents) {
+	if err != nil {
 		return err
-	} else if errors.Is(err, core.ErrNoEvents) && root.Version() == 0 {
-		// no events and not based on a snapshot
-		return ErrAggregateNotFound
 	}
 	defer eventIterator.Close()
 
@@ -182,7 +179,7 @@ func (r *Repository) GetWithContext(ctx context.Context, id string, a aggregate)
 		}
 	}
 	if a.Root().Version() == 0 {
-		return fmt.Errorf("TODO: replace with custom error")
+		return ErrAggregateNotFound
 	}
 	return nil
 }


### PR DESCRIPTION
Change the iterator interface to make the communication between the event store's and the main package smoother.

Before:
```go
type Iterator interface {
 	Next() (Event, error)
 	Close()
 }
```

After:
```go
type Iterator interface {
 	Next() bool
 	Value() (Event, error)
 	Close()
 }
```

The error handling is a lot simpler as the end of an event stream does not have to be returned as en error anymore.