### PR TITLE
Internal package

### DIFF
--- a/aggregateroot.go
+++ b/aggregateroot.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/hallgren/eventsourcing/core"
+	"github.com/hallgren/eventsourcing/internal"
 )
 
 // AggregateRoot to be included into aggregates
@@ -45,7 +46,7 @@ func (ar *AggregateRoot) TrackChangeWithMetadata(a aggregate, data interface{}, 
 		event: core.Event{
 			AggregateID:   ar.aggregateID,
 			Version:       ar.nextVersion(),
-			AggregateType: aggregateType(a),
+			AggregateType: internal.AggregateType(a),
 			Timestamp:     time.Now().UTC(),
 		},
 		data:     data,
@@ -134,8 +135,4 @@ func (ar *AggregateRoot) Events() []Event {
 // UnsavedEvents return true if there's unsaved events on the aggregate
 func (ar *AggregateRoot) UnsavedEvents() bool {
 	return len(ar.aggregateEvents) > 0
-}
-
-func aggregateType(a aggregate) string {
-	return reflect.TypeOf(a).Elem().Name()
 }

--- a/eventstream.go
+++ b/eventstream.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+
+	"github.com/hallgren/eventsourcing/internal"
 )
 
 // EventStream struct that handles event subscription
@@ -135,7 +137,7 @@ func (e *EventStream) AggregateID(f func(e Event), aggregates ...aggregate) *sub
 	defer e.lock.Unlock()
 
 	for _, a := range aggregates {
-		name := aggregateType(a)
+		name := internal.AggregateType(a)
 		root := a.Root()
 		ref := fmt.Sprintf("%s_%s_%s", root.path(), name, root.ID())
 
@@ -163,7 +165,7 @@ func (e *EventStream) Aggregate(f func(e Event), aggregates ...aggregate) *subsc
 	defer e.lock.Unlock()
 
 	for _, a := range aggregates {
-		name := aggregateType(a)
+		name := internal.AggregateType(a)
 		root := a.Root()
 		ref := fmt.Sprintf("%s_%s", root.path(), name)
 

--- a/example/go.mod
+++ b/example/go.mod
@@ -2,4 +2,6 @@ module github.com/hallgren/eventsourcing/example
 
 go 1.13
 
-require github.com/hallgren/eventsourcing v0.3.0
+require github.com/hallgren/eventsourcing v0.4.0
+
+replace github.com/hallgren/eventsourcing => ../.

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,4 +1,2 @@
-github.com/hallgren/eventsourcing v0.3.0 h1:uP/aul8eki8uHLs4ouHLSNlFoZBaC9siHyw8B2ZtA2o=
-github.com/hallgren/eventsourcing v0.3.0/go.mod h1:g2v+slU/ctICDtNsyh1F3NYgIYytaMUDPMssdkQDxv4=
-github.com/hallgren/eventsourcing/core v0.3.0 h1:v6AC8+SEzZ0DAFfSRmyT+sFawBv3olHJFEWXm79FpjM=
-github.com/hallgren/eventsourcing/core v0.3.0/go.mod h1:rgo2kFwNVCb0bzUub5nOPlUYNlFkp1uUQBEQx5fM3Lk=
+github.com/hallgren/eventsourcing/core v0.4.0 h1:a11TT3df7JlrZtIogqbGmLGgmeugRavwD8HrLtW1Uxw=
+github.com/hallgren/eventsourcing/core v0.4.0/go.mod h1:rgo2kFwNVCb0bzUub5nOPlUYNlFkp1uUQBEQx5fM3Lk=

--- a/example/main.go
+++ b/example/main.go
@@ -12,7 +12,7 @@ func main() {
 	var c = make(chan eventsourcing.Event)
 	// Setup a memory based event store
 	eventStore := memory.Create()
-	repo := eventsourcing.NewRepository(eventStore)
+	repo := eventsourcing.NewEventRepository(eventStore)
 	repo.Register(&FrequentFlierAccountAggregate{})
 
 	f := func(e eventsourcing.Event) {

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require github.com/hallgren/eventsourcing/core v0.4.0
 
-// replace github.com/hallgren/eventsourcing/core => ./core
+replace github.com/hallgren/eventsourcing/core => ./core

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.13
 
 require github.com/hallgren/eventsourcing/core v0.4.0
 
-replace github.com/hallgren/eventsourcing/core => ./core
+// replace github.com/hallgren/eventsourcing/core => ./core

--- a/snapshotrepository.go
+++ b/snapshotrepository.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 
 	"github.com/hallgren/eventsourcing/core"
+	"github.com/hallgren/eventsourcing/internal"
 )
 
 // ErrUnsavedEvents aggregate events must be saved before creating snapshot
@@ -74,7 +75,7 @@ func (s *SnapshotRepository) GetSnapshot(ctx context.Context, id string, a aggre
 }
 
 func (s *SnapshotRepository) getSnapshot(ctx context.Context, id string, a aggregate) error {
-	snapshot, err := s.snapshotStore.Get(ctx, id, aggregateType(a))
+	snapshot, err := s.snapshotStore.Get(ctx, id, internal.AggregateType(a))
 	if err != nil {
 		return err
 	}
@@ -138,7 +139,7 @@ func (s *SnapshotRepository) SaveSnapshot(a aggregate) error {
 
 	snapshot := core.Snapshot{
 		ID:            root.ID(),
-		Type:          aggregateType(a),
+		Type:          internal.AggregateType(a),
 		Version:       core.Version(root.Version()),
 		GlobalVersion: core.Version(root.GlobalVersion()),
 		State:         state,


### PR DESCRIPTION
Start use an internal package to hide structs, methods and functions that does not have to be public to the outside.