### PR TITLE
bbolt eventstore refactor

### DIFF
--- a/aggregateroot_test.go
+++ b/aggregateroot_test.go
@@ -76,6 +76,13 @@ func (person *Person) Transition(event eventsourcing.Event) {
 	}
 }
 
+func TestPersonWithNoEvents(t *testing.T) {
+	person := Person{}
+	if person.Version() != 0 {
+		t.Fatalf("should have version 0 had %d", person.Version())
+	}
+}
+
 func TestCreateNewPerson(t *testing.T) {
 	timeBefore := time.Now().UTC()
 	person, err := CreatePerson("kalle")

--- a/eventstore/bbolt/go.mod
+++ b/eventstore/bbolt/go.mod
@@ -3,9 +3,9 @@ module github.com/hallgren/eventsourcing/eventstore/bbolt
 go 1.13
 
 require (
-	github.com/hallgren/eventsourcing/core v0.3.0
-	go.etcd.io/bbolt v1.3.7
-	golang.org/x/sys v0.10.0 // indirect
+	github.com/hallgren/eventsourcing/core v0.4.0
+	go.etcd.io/bbolt v1.3.8
+	golang.org/x/sys v0.17.0 // indirect
 )
 
 // replace github.com/hallgren/eventsourcing/core => ../../core

--- a/eventstore/bbolt/go.sum
+++ b/eventstore/bbolt/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hallgren/eventsourcing/core v0.3.0 h1:v6AC8+SEzZ0DAFfSRmyT+sFawBv3olHJFEWXm79FpjM=
-github.com/hallgren/eventsourcing/core v0.3.0/go.mod h1:rgo2kFwNVCb0bzUub5nOPlUYNlFkp1uUQBEQx5fM3Lk=
+github.com/hallgren/eventsourcing/core v0.4.0 h1:a11TT3df7JlrZtIogqbGmLGgmeugRavwD8HrLtW1Uxw=
+github.com/hallgren/eventsourcing/core v0.4.0/go.mod h1:rgo2kFwNVCb0bzUub5nOPlUYNlFkp1uUQBEQx5fM3Lk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -12,12 +12,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
-go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
+go.etcd.io/bbolt v1.3.8 h1:xs88BrvEv273UsB79e0hcVrlUWmS0a8upikMFhSyAtA=
+go.etcd.io/bbolt v1.3.8/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.etcd.io/gofail v0.1.0/go.mod h1:VZBCXYGZhHAinaBiiqYvuDynvahNsAyLFwB3kEHKz1M=
 golang.org/x/sys v0.4.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.10.0 h1:SqMFp9UcQJZa+pmYuAKjd9xq1f0j5rLcDIk0mj4qAsA=
-golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.17.0 h1:25cE3gD+tdBA7lp7QfhuV+rJiE9YXTcS3VG1SqssI/Y=
+golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/eventstore/bbolt/iterator.go
+++ b/eventstore/bbolt/iterator.go
@@ -12,7 +12,7 @@ import (
 type iterator struct {
 	tx            *bbolt.Tx
 	cursor        *bbolt.Cursor
-	startPosition uint64
+	startPosition []byte
 	value         []byte
 }
 
@@ -22,18 +22,16 @@ func (i *iterator) Close() {
 }
 
 func (i *iterator) Next() bool {
-	var value []byte
-	// first time Next is called
+	// first time Next is called go to the start position
 	if i.value == nil {
-		_, value = i.cursor.Seek(itob(i.startPosition))
+		_, i.value = i.cursor.Seek(i.startPosition)
 	} else {
-		_, value = i.cursor.Next()
+		_, i.value = i.cursor.Next()
 	}
 
-	if value == nil {
+	if i.value == nil {
 		return false
 	}
-	i.value = value
 	return true
 }
 

--- a/eventstore/bbolt/iterator.go
+++ b/eventstore/bbolt/iterator.go
@@ -10,11 +10,9 @@ import (
 )
 
 type iterator struct {
-	tx              *bbolt.Tx
-	bucketName      string
-	firstEventIndex uint64
-	cursor          *bbolt.Cursor
-	value           []byte
+	tx     *bbolt.Tx
+	cursor *bbolt.Cursor
+	value  []byte
 }
 
 // Close closes the iterator
@@ -24,19 +22,8 @@ func (i *iterator) Close() {
 
 func (i *iterator) Next() bool {
 	var value []byte
-	if i.cursor == nil {
-		bucket := i.tx.Bucket([]byte(i.bucketName))
-		if bucket == nil {
-			return false
-		}
-		i.cursor = bucket.Cursor()
-		_, value = i.cursor.Seek(itob(i.firstEventIndex))
-		if value == nil {
-			return false
-		}
-	} else {
-		_, value = i.cursor.Next()
-	}
+	_, value = i.cursor.Next()
+
 	if value == nil {
 		return false
 	}

--- a/eventstore/bbolt/iterator.go
+++ b/eventstore/bbolt/iterator.go
@@ -10,9 +10,10 @@ import (
 )
 
 type iterator struct {
-	tx     *bbolt.Tx
-	cursor *bbolt.Cursor
-	value  []byte
+	tx            *bbolt.Tx
+	cursor        *bbolt.Cursor
+	startPosition uint64
+	value         []byte
 }
 
 // Close closes the iterator
@@ -22,7 +23,12 @@ func (i *iterator) Close() {
 
 func (i *iterator) Next() bool {
 	var value []byte
-	_, value = i.cursor.Next()
+	// first time Next is called
+	if i.value == nil {
+		_, value = i.cursor.Seek(itob(i.startPosition))
+	} else {
+		_, value = i.cursor.Next()
+	}
 
 	if value == nil {
 		return false


### PR DESCRIPTION
Make use of the underlaying cursor instead of reading the events into memory before iterating.