### PR TITLE
sqlite event store

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,6 +62,23 @@ jobs:
       - name: Test
         run: cd eventstore/sql && go test -v ./...
 
+  sqlite:
+    name: sqlite eventstore
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.19'
+
+      - name: Build
+        run: cd eventstore/sqlite && go build -v ./...
+
+      - name: Test
+        run: cd eventstore/sqlite && go test -v ./...
+
   esdb:
     name: esdb eventstore
     runs-on: ubuntu-latest

--- a/eventstore/sqlite/go.mod
+++ b/eventstore/sqlite/go.mod
@@ -1,0 +1,10 @@
+module github.com/hallgren/eventsourcing/eventstore/sqlite
+
+go 1.21.9
+
+require (
+	github.com/hallgren/eventsourcing/eventstore/sql v0.4.1
+	github.com/mattn/go-sqlite3 v1.14.22
+)
+
+require github.com/hallgren/eventsourcing/core v0.4.0

--- a/eventstore/sqlite/go.mod
+++ b/eventstore/sqlite/go.mod
@@ -1,6 +1,6 @@
 module github.com/hallgren/eventsourcing/eventstore/sqlite
 
-go 1.21.9
+go 1.13
 
 require (
 	github.com/hallgren/eventsourcing/eventstore/sql v0.4.1

--- a/eventstore/sqlite/go.sum
+++ b/eventstore/sqlite/go.sum
@@ -1,0 +1,6 @@
+github.com/hallgren/eventsourcing/core v0.4.0 h1:a11TT3df7JlrZtIogqbGmLGgmeugRavwD8HrLtW1Uxw=
+github.com/hallgren/eventsourcing/core v0.4.0/go.mod h1:rgo2kFwNVCb0bzUub5nOPlUYNlFkp1uUQBEQx5fM3Lk=
+github.com/hallgren/eventsourcing/eventstore/sql v0.4.1 h1:KIdB0eVH2XBsUdHxVipWKgkd/CsmHhBcij+EJZFo7MU=
+github.com/hallgren/eventsourcing/eventstore/sql v0.4.1/go.mod h1:q5idyOFHCQP9KKFE07h6shMKCjZap6Gm9Q603bDxVpc=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=

--- a/eventstore/sqlite/sqlite.go
+++ b/eventstore/sqlite/sqlite.go
@@ -1,0 +1,49 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+
+	"github.com/hallgren/eventsourcing/core"
+	essql "github.com/hallgren/eventsourcing/eventstore/sql"
+)
+
+type SQLite struct {
+	sqlES *essql.SQL
+	lock  sync.Mutex
+}
+
+func Open(db *sql.DB) *SQLite {
+	return &SQLite{
+		sqlES: essql.Open(db),
+		lock:  sync.Mutex{},
+	}
+}
+
+func (s *SQLite) Close() {
+	s.sqlES.Close()
+}
+
+// Save persists events to the database
+func (s *SQLite) Save(events []core.Event) error {
+	// prevent multiple writters
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.sqlES.Save(events)
+}
+
+// Get the events from database
+func (s *SQLite) Get(ctx context.Context, id string, aggregateType string, afterVersion core.Version) (core.Iterator, error) {
+	return s.sqlES.Get(ctx, id, aggregateType, afterVersion)
+}
+
+// All iterate over all event in GlobalEvents order
+func (s *SQLite) All(start core.Version, count uint64) (core.Iterator, error) {
+	return s.sqlES.All(start, count)
+}
+
+// Migrate creates the database schema if not already present
+func (s *SQLite) Migrate() error {
+	return s.sqlES.Migrate()
+}

--- a/eventstore/sqlite/sqlite.go
+++ b/eventstore/sqlite/sqlite.go
@@ -27,7 +27,7 @@ func (s *SQLite) Close() {
 
 // Save persists events to the database
 func (s *SQLite) Save(events []core.Event) error {
-	// prevent multiple writters
+	// prevent multiple writers
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.sqlES.Save(events)

--- a/eventstore/sqlite/sqlite_test.go
+++ b/eventstore/sqlite/sqlite_test.go
@@ -1,0 +1,40 @@
+package sqlite_test
+
+import (
+	sqldriver "database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/hallgren/eventsourcing/core"
+	"github.com/hallgren/eventsourcing/core/testsuite"
+	"github.com/hallgren/eventsourcing/eventstore/sqlite"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestSuite(t *testing.T) {
+	f := func() (core.EventStore, func(), error) {
+		return eventstore()
+	}
+	testsuite.Test(t, f)
+}
+
+func eventstore() (*sqlite.SQLite, func(), error) {
+	db, err := sqldriver.Open("sqlite3", "file::memory:?cache=shared")
+	if err != nil {
+		return nil, nil, errors.New(fmt.Sprintf("could not open database %v", err))
+	}
+	err = db.Ping()
+	if err != nil {
+		return nil, nil, errors.New(fmt.Sprintf("could not ping database %v", err))
+	}
+
+	es := sqlite.Open(db)
+	err = es.Migrate()
+	if err != nil {
+		return nil, nil, errors.New(fmt.Sprintf("could not migrate database %v", err))
+	}
+	return es, func() {
+		es.Close()
+	}, nil
+}


### PR DESCRIPTION
The only change compared to the sql event store is a mutex preventing multiple writers saving events concurrently.