### PR TITLE
chore(aggregate)!: aggregate interface method Root -> root

### DIFF
--- a/aggregateroot.go
+++ b/aggregateroot.go
@@ -102,8 +102,8 @@ func (ar *AggregateRoot) ID() string {
 	return ar.aggregateID
 }
 
-// Root returns the included Aggregate Root state, and is used from the interface Aggregate.
-func (ar *AggregateRoot) Root() *AggregateRoot {
+// root returns the included Aggregate Root state, and is used from the interface Aggregate.
+func (ar *AggregateRoot) root() *AggregateRoot {
 	return ar
 }
 

--- a/eventrepository.go
+++ b/eventrepository.go
@@ -11,7 +11,7 @@ import (
 
 // Aggregate interface to use the aggregate root specific methods
 type aggregate interface {
-	Root() *AggregateRoot
+	root() *AggregateRoot
 	Transition(event Event)
 	Register(RegisterFunc)
 }
@@ -92,7 +92,7 @@ func (er *EventRepository) Save(a aggregate) error {
 	if !er.register.AggregateRegistered(a) {
 		return ErrAggregateNotRegistered
 	}
-	root := a.Root()
+	root := a.root()
 
 	// return as quick as possible when no events to process
 	if len(root.aggregateEvents) == 0 {
@@ -153,7 +153,7 @@ func (er *EventRepository) GetWithContext(ctx context.Context, id string, a aggr
 		return ErrAggregateNeedsToBeAPointer
 	}
 
-	root := a.Root()
+	root := a.root()
 	aggregateType := aggregateType(a)
 	// fetch events after the current version of the aggregate that could be fetched from the snapshot store
 	eventIterator, err := er.eventStore.Get(ctx, id, aggregateType, core.Version(root.aggregateVersion))
@@ -191,7 +191,7 @@ func (er *EventRepository) GetWithContext(ctx context.Context, id string, a aggr
 			root.BuildFromHistory(a, []Event{e})
 		}
 	}
-	if a.Root().Version() == 0 {
+	if a.root().Version() == 0 {
 		return ErrAggregateNotFound
 	}
 	return nil

--- a/eventstream.go
+++ b/eventstream.go
@@ -136,7 +136,7 @@ func (e *EventStream) AggregateID(f func(e Event), aggregates ...aggregate) *sub
 
 	for _, a := range aggregates {
 		name := aggregateType(a)
-		root := a.Root()
+		root := a.root()
 		ref := fmt.Sprintf("%s_%s_%s", root.path(), name, root.ID())
 
 		// adds one more function to the aggregate
@@ -164,7 +164,7 @@ func (e *EventStream) Aggregate(f func(e Event), aggregates ...aggregate) *subsc
 
 	for _, a := range aggregates {
 		name := aggregateType(a)
-		root := a.Root()
+		root := a.root()
 		ref := fmt.Sprintf("%s_%s", root.path(), name)
 
 		// adds one more function to the aggregate

--- a/snapshotrepository.go
+++ b/snapshotrepository.go
@@ -94,7 +94,7 @@ func (s *SnapshotRepository) getSnapshot(ctx context.Context, id string, a aggre
 	}
 
 	// set the internal aggregate properties
-	root := a.Root()
+	root := a.root()
 	root.aggregateGlobalVersion = Version(snapshot.GlobalVersion)
 	root.aggregateVersion = Version(snapshot.Version)
 	root.aggregateID = snapshot.ID
@@ -115,7 +115,7 @@ func (s *SnapshotRepository) Save(a aggregate) error {
 
 // SaveSnapshot will only store the snapshot and will return an error if there are events that are not stored
 func (s *SnapshotRepository) SaveSnapshot(a aggregate) error {
-	root := a.Root()
+	root := a.root()
 	if len(root.Events()) > 0 {
 		return ErrUnsavedEvents
 	}


### PR DESCRIPTION
Hide the method on the aggregate interface as for internal use only.