### PR TITLE
Fix empty ErrEventNotRegistered error message

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -27,7 +27,11 @@ func (i *Iterator) Value() (Event, error) {
 	// apply the event to the aggregate
 	f, found := internal.GlobalRegister.EventRegistered(event)
 	if !found {
-		return Event{}, ErrEventNotRegistered
+		return Event{
+			event:    event,
+			data:     nil,
+			metadata: nil,
+		}, ErrEventNotRegistered
 	}
 	data := f()
 	err = internal.EventEncoder.Deserialize(event.Data, &data)

--- a/iterator.go
+++ b/iterator.go
@@ -27,11 +27,7 @@ func (i *Iterator) Value() (Event, error) {
 	// apply the event to the aggregate
 	f, found := internal.GlobalRegister.EventRegistered(event)
 	if !found {
-		return Event{
-			event:    event,
-			data:     nil,
-			metadata: nil,
-		}, ErrEventNotRegistered
+		return Event{}, fmt.Errorf("event not registered, aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType(), event.event.Reason, event.GlobalVersion(), ErrEventNotRegistered)
 	}
 	data := f()
 	err = internal.EventEncoder.Deserialize(event.Data, &data)

--- a/iterator.go
+++ b/iterator.go
@@ -1,6 +1,7 @@
 package eventsourcing
 
 import (
+	"fmt"
 	"github.com/hallgren/eventsourcing/core"
 	"github.com/hallgren/eventsourcing/internal"
 )
@@ -27,7 +28,7 @@ func (i *Iterator) Value() (Event, error) {
 	// apply the event to the aggregate
 	f, found := internal.GlobalRegister.EventRegistered(event)
 	if !found {
-		return Event{}, fmt.Errorf("event not registered, aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType(), event.event.Reason, event.GlobalVersion(), ErrEventNotRegistered)
+		return Event{}, fmt.Errorf("event not registered, aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType, event.Reason, event.GlobalVersion, ErrEventNotRegistered)
 	}
 	data := f()
 	err = internal.EventEncoder.Deserialize(event.Data, &data)

--- a/projections.go
+++ b/projections.go
@@ -3,7 +3,6 @@ package eventsourcing
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/projections.go
+++ b/projections.go
@@ -164,7 +164,7 @@ func (p *Projection) RunOnce() (bool, ProjectionResult) {
 		if err != nil {
 			if errors.Is(err, ErrEventNotRegistered) {
 				if p.Strict {
-					err = fmt.Errorf("event not registered aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType(), event.Reason(), event.GlobalVersion(), ErrEventNotRegistered)
+					err = fmt.Errorf("event not registered aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType(), event.event.Reason, event.GlobalVersion(), ErrEventNotRegistered)
 					return false, ProjectionResult{Error: err, Name: p.Name, LastHandledEvent: lastHandledEvent}
 				}
 				continue

--- a/projections.go
+++ b/projections.go
@@ -164,7 +164,6 @@ func (p *Projection) RunOnce() (bool, ProjectionResult) {
 		if err != nil {
 			if errors.Is(err, ErrEventNotRegistered) {
 				if p.Strict {
-					err = fmt.Errorf("event not registered aggregate type: %s, reason: %s, global version: %d, %w", event.AggregateType(), event.event.Reason, event.GlobalVersion(), ErrEventNotRegistered)
 					return false, ProjectionResult{Error: err, Name: p.Name, LastHandledEvent: lastHandledEvent}
 				}
 				continue

--- a/projections_test.go
+++ b/projections_test.go
@@ -402,11 +402,6 @@ func TestStrict(t *testing.T) {
 	if !errors.Is(result.Error, eventsourcing.ErrEventNotRegistered) {
 		t.Fatalf("expected ErrEventNotRegistered got %q", err.Error())
 	}
-
-	expected := "event not registered aggregate type: Person, reason: Born, global version: 1, event not registered"
-	if result.Error.Error() != expected {
-		t.Fatalf(`expected "%s", got %q`, expected, result.Error)
-	}
 }
 
 func TestRace(t *testing.T) {

--- a/projections_test.go
+++ b/projections_test.go
@@ -402,6 +402,11 @@ func TestStrict(t *testing.T) {
 	if !errors.Is(result.Error, eventsourcing.ErrEventNotRegistered) {
 		t.Fatalf("expected ErrEventNotRegistered got %q", err.Error())
 	}
+
+	expected := "event not registered aggregate type: Person, reason: Born, global version: 1, event not registered"
+	if result.Error.Error() != expected {
+		t.Fatalf(`expected "%s", got %q`, expected, result.Error)
+	}
 }
 
 func TestRace(t *testing.T) {


### PR DESCRIPTION
Return `Event` containing the underlying `event` from iterator so that error message values can be populated.

Resolves https://github.com/hallgren/eventsourcing/issues/160

I'm not confident that this is the best way of resolving the issue, but worked for me locally when trying to debug my project.