### PR TITLE
chore: restructure internals and remove dead code

### DIFF
--- a/aggregate/aggregate.go
+++ b/aggregate/aggregate.go
@@ -66,7 +66,7 @@ func Save(es core.EventStore, a aggregate) error {
 	root := a.root()
 
 	// return as quick as possible when no events to process
-	if len(root.aggregateEvents) == 0 {
+	if len(root.events) == 0 {
 		return nil
 	}
 
@@ -79,12 +79,12 @@ func Save(es core.EventStore, a aggregate) error {
 		return err
 	}
 	// update the global version on the aggregate
-	root.aggregateGlobalVersion = globalVersion
+	root.globalVersion = globalVersion
 
 	// set internal properties and reset the events slice
-	lastEvent := root.aggregateEvents[len(root.aggregateEvents)-1]
-	root.aggregateVersion = lastEvent.Version()
-	root.aggregateEvents = []eventsourcing.Event{}
+	lastEvent := root.events[len(root.events)-1]
+	root.version = lastEvent.Version()
+	root.events = []eventsourcing.Event{}
 
 	return nil
 }

--- a/aggregate/root.go
+++ b/aggregate/root.go
@@ -10,13 +10,13 @@ import (
 
 // Root to be included into aggregates to give it the aggregate root behaviors
 type Root struct {
-	aggregateID            string
-	aggregateVersion       eventsourcing.Version
-	aggregateGlobalVersion eventsourcing.Version
-	aggregateEvents        []eventsourcing.Event
+	id            string
+	version       eventsourcing.Version
+	globalVersion eventsourcing.Version
+	events        []eventsourcing.Event
 }
 
-const emptyAggregateID = ""
+const emptyID = ""
 
 // TrackChange is used internally by behaviour methods to apply a state change to
 // the current instance and also track it in order that it can be persisted later.
@@ -30,13 +30,13 @@ func TrackChange(a aggregate, data interface{}) {
 func TrackChangeWithMetadata(a aggregate, data interface{}, metadata map[string]interface{}) {
 	ar := a.root()
 	// This can be overwritten in the constructor of the aggregate
-	if ar.aggregateID == emptyAggregateID {
-		ar.aggregateID = idFunc()
+	if ar.id == emptyID {
+		ar.id = idFunc()
 	}
 
 	event := eventsourcing.NewEvent(
 		core.Event{
-			AggregateID:   ar.aggregateID,
+			AggregateID:   ar.id,
 			Version:       ar.nextVersion(),
 			AggregateType: aggregateType(a),
 			Timestamp:     time.Now().UTC(),
@@ -44,7 +44,7 @@ func TrackChangeWithMetadata(a aggregate, data interface{}, metadata map[string]
 		data,
 		metadata,
 	)
-	ar.aggregateEvents = append(ar.aggregateEvents, event)
+	ar.events = append(ar.events, event)
 	a.Transition(event)
 }
 
@@ -54,10 +54,10 @@ func buildFromHistory(a aggregate, events []eventsourcing.Event) {
 	for _, event := range events {
 		a.Transition(event)
 		//Set the aggregate ID
-		root.aggregateID = event.AggregateID()
+		root.id = event.AggregateID()
 		// Make sure the aggregate is in the correct version (the last event)
-		root.aggregateVersion = event.Version()
-		root.aggregateGlobalVersion = event.GlobalVersion()
+		root.version = event.Version()
+		root.globalVersion = event.GlobalVersion()
 	}
 }
 
@@ -65,61 +65,48 @@ func (ar *Root) nextVersion() core.Version {
 	return core.Version(ar.Version()) + 1
 }
 
-// update sets the AggregateVersion and AggregateGlobalVersion to the values in the last event
-// This function is called after the aggregate is saved in the repository
-func (ar *Root) update() {
-	if len(ar.aggregateEvents) > 0 {
-		lastEvent := ar.aggregateEvents[len(ar.aggregateEvents)-1]
-		ar.aggregateVersion = lastEvent.Version()
-		ar.aggregateGlobalVersion = lastEvent.GlobalVersion()
-		ar.aggregateEvents = []eventsourcing.Event{}
-	}
-}
-
-// path return the full name of the aggregate making it unique to other aggregates with
-// the same name but placed in other packages.
-func (ar *Root) path() string {
-	return reflect.TypeOf(ar).Elem().PkgPath()
-}
-
 // SetID opens up the possibility to set manual aggregate ID from the outside
 func (ar *Root) SetID(id string) error {
-	if ar.aggregateID != emptyAggregateID {
+	if ar.id != emptyID {
 		return eventsourcing.ErrAggregateAlreadyExists
 	}
-	ar.aggregateID = id
+	ar.id = id
 	return nil
 }
 
 // ID returns the aggregate ID as a string
 func (ar *Root) ID() string {
-	return ar.aggregateID
+	return ar.id
 }
 
 // root returns the included Aggregate Root state, and is used from the interface Aggregate.
+//
+//nolint:unused
 func (ar *Root) root() *Root {
 	return ar
 }
 
 // Version return the version based on events that are not stored
 func (ar *Root) Version() eventsourcing.Version {
-	if len(ar.aggregateEvents) > 0 {
-		return ar.aggregateEvents[len(ar.aggregateEvents)-1].Version()
+	if len(ar.events) > 0 {
+		return ar.events[len(ar.events)-1].Version()
 	}
-	return eventsourcing.Version(ar.aggregateVersion)
+	return eventsourcing.Version(ar.version)
 }
 
 // GlobalVersion returns the global version based on the last stored event
 func (ar *Root) GlobalVersion() eventsourcing.Version {
-	return eventsourcing.Version(ar.aggregateGlobalVersion)
+	return eventsourcing.Version(ar.globalVersion)
 }
 
 // Events return the aggregate events from the aggregate
 // make a copy of the slice preventing outsiders modifying events.
+//
+//nolint:gosimple // for some reason copy does not work
 func (ar *Root) Events() []eventsourcing.Event {
-	e := make([]eventsourcing.Event, len(ar.aggregateEvents))
+	e := make([]eventsourcing.Event, len(ar.events))
 	// convert internal event to external event
-	for i, event := range ar.aggregateEvents {
+	for i, event := range ar.events {
 		e[i] = event
 	}
 	return e
@@ -127,7 +114,7 @@ func (ar *Root) Events() []eventsourcing.Event {
 
 // UnsavedEvents return true if there's unsaved events on the aggregate
 func (ar *Root) UnsavedEvents() bool {
-	return len(ar.aggregateEvents) > 0
+	return len(ar.events) > 0
 }
 
 func aggregateType(a interface{}) string {

--- a/aggregate/snapshot.go
+++ b/aggregate/snapshot.go
@@ -51,9 +51,9 @@ func getSnapshot(ctx context.Context, ss core.SnapshotStore, id string, s snapsh
 
 	// set the internal aggregate properties
 	root := s.root()
-	root.aggregateGlobalVersion = eventsourcing.Version(snap.GlobalVersion)
-	root.aggregateVersion = eventsourcing.Version(snap.Version)
-	root.aggregateID = snap.ID
+	root.globalVersion = eventsourcing.Version(snap.GlobalVersion)
+	root.version = eventsourcing.Version(snap.Version)
+	root.id = snap.ID
 
 	return nil
 }


### PR DESCRIPTION
* Removed the aggregate name extension as the variables are already in the aggregate package.
* Removed the unused methods `update` and `path` from the aggregate root.